### PR TITLE
Fix Issue #165: Status of PromptTextHelpful always be bad

### DIFF
--- a/dingo/model/llm/llm_text_3h.py
+++ b/dingo/model/llm/llm_text_3h.py
@@ -40,7 +40,7 @@ class LLMText3H(BaseOpenAI):
         result = ModelRes()
 
         # error_status
-        if response_model.score == "1":
+        if response_model.score == 1:
             result.reason = [response_model.reason]
             result.name = cls.prompt.__name__[8:].upper()
         else:


### PR DESCRIPTION
Fix Issue #165 
Because the score returned by the model is converted to a number, but the code compares it with a string, the comparison structure is always False.
Before fix:
<img width="1246" height="508" alt="image" src="https://github.com/user-attachments/assets/d6084a1a-f451-4001-854f-2887fa6b1826" />
After fix:
<img width="1228" height="519" alt="image" src="https://github.com/user-attachments/assets/7d438ad0-ee62-4716-9e6a-7223a4bb7d73" />
