### PR TITLE
fix: Isolate evaluator dynamic configs

### DIFF
--- a/dingo/model/model.py
+++ b/dingo/model/model.py
@@ -157,7 +157,7 @@ class Model:
     def set_config_rule(cls, rule: BaseRule, rule_config: EvaluatorRuleArgs):
         if not rule_config:
             return
-        config_default = getattr(rule, 'dynamic_config')
+        config_default = rule.dynamic_config.model_copy(deep=True)
         # Iterate over rule_config fields using Pydantic's model_dump()
         for k, v in rule_config.model_dump().items():
             if v is not None:
@@ -168,7 +168,7 @@ class Model:
     def set_config_llm(cls, llm: BaseLLM, llm_config: EvaluatorLLMArgs):
         if not llm_config:
             return
-        config_default = getattr(llm, 'dynamic_config')
+        config_default = llm.dynamic_config.model_copy(deep=True)
         # Iterate over llm_config fields using Pydantic's model_dump()
         for k, v in llm_config.model_dump().items():
             if v is not None:

--- a/test/scripts/model/test_model_config_isolation.py
+++ b/test/scripts/model/test_model_config_isolation.py
@@ -1,0 +1,41 @@
+from dingo.config.input_args import EvaluatorLLMArgs, EvaluatorRuleArgs
+from dingo.model.llm.text_quality.llm_text_quality_v5 import LLMTextQualityV5
+from dingo.model.model import Model
+from dingo.model.rule.rule_common import RulePatternSearch
+
+
+def test_set_config_rule_copies_dynamic_config_per_rule_object():
+    rule_a = RulePatternSearch()
+    rule_b = RulePatternSearch()
+
+    Model.set_config_rule(rule_a, EvaluatorRuleArgs(pattern="apple"))
+    Model.set_config_rule(rule_b, EvaluatorRuleArgs(pattern="banana"))
+
+    assert rule_a.dynamic_config is not rule_b.dynamic_config
+    assert rule_a.dynamic_config.pattern == "apple"
+    assert rule_b.dynamic_config.pattern == "banana"
+    assert RulePatternSearch.dynamic_config.pattern == "your pattern"
+
+
+def test_set_config_llm_copies_dynamic_config_per_llm_object():
+    # This verifies config object isolation only. Existing classmethod LLM evaluators
+    # still read cls.dynamic_config at runtime unless separately refactored.
+    llm_a = LLMTextQualityV5()
+    llm_b = LLMTextQualityV5()
+
+    Model.set_config_llm(
+        llm_a,
+        EvaluatorLLMArgs(model="model-a", parameters={"temperature": 0.1}),
+    )
+    Model.set_config_llm(
+        llm_b,
+        EvaluatorLLMArgs(model="model-b", parameters={"temperature": 0.9}),
+    )
+
+    assert llm_a.dynamic_config is not llm_b.dynamic_config
+    assert llm_a.dynamic_config.model == "model-a"
+    assert llm_b.dynamic_config.model == "model-b"
+    assert llm_a.dynamic_config.parameters == {"temperature": 0.1}
+    assert llm_b.dynamic_config.parameters == {"temperature": 0.9}
+    assert LLMTextQualityV5.dynamic_config.model is None
+    assert LLMTextQualityV5.dynamic_config.model_dump().get("parameters") is None


### PR DESCRIPTION
  ## 背景

  此前配置注入会直接复用 evaluator 类上的 `dynamic_config` 对象。
  当多个 evaluator 实例分别设置不同配置时，后一次配置可能覆盖前一次配置，并污染类上的默认配置。

  本 PR 先修复配置对象共享污染问题，为后续支持 `LLMCustomRule` 做基础准备。

  ## 变更内容

  - 在 `Model.set_config_rule()` 中，应用用户配置前先 deepcopy 默认 `dynamic_config`。
  - 在 `Model.set_config_llm()` 中，同样先 deepcopy 默认 `dynamic_config`，再应用用户配置。
  - 新增 rule / LLM evaluator 配置隔离单测。

  ## 测试

  ```bash
  python -m pytest -q test/scripts/model/test_modelres.py test/scripts/model/test_model_config_isolation.py