### PR TITLE
fix: inject llm config into class in local executor

### DIFF
--- a/dingo/config/input_args.py
+++ b/dingo/config/input_args.py
@@ -87,6 +87,8 @@ class ExecutorArgs(BaseModel):
 
 
 class EvaluatorRuleArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+
     threshold: Optional[float] = None
     pattern: Optional[str] = None
     key_list: Optional[List[str]] = None
@@ -119,7 +121,7 @@ class EvaluatorLLMArgs(BaseModel):
 
 
 class EvalPiplineConfig(BaseModel):
-    """Single evaluator configuration item"""
+    """Single evaluator configuration item."""
     name: str
     config: Optional[EvaluatorRuleArgs | EvaluatorLLMArgs] = None
 

--- a/dingo/exec/local.py
+++ b/dingo/exec/local.py
@@ -178,8 +178,9 @@ class LocalExecutor(ExecProto):
                 Model.set_config_rule(model, e_c_i.config)
             elif eval_type == 'llm':
                 model_cls = Model.llm_name_map.get(e_c_i.name)
-                model = model_cls()  # 实例化类为对象，避免多线程配置覆盖
+                model = model_cls()
                 Model.set_config_llm(model, e_c_i.config)
+                Model.set_config_llm(model_cls, e_c_i.config)
             else:
                 raise ValueError(f"Error eval_type: {eval_type}")
 


### PR DESCRIPTION
Base branch: origin/dev\n\nSummary:\n- set LLM evaluator config on both the instance and class before local execution\n- fixes built-in classmethod LLM evaluators reading the default class dynamic_config and seeing an empty key\n- keeps CustomLLMMetric structured config parsing intact\n\nVerification:\n- PYTHONPATH=/Users/danielsu/intern/shAILab/dingo PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q test/scripts/model/llm/test_llm_custom_metric.py test/scripts/model/test_model_config_isolation.py\n\nNotes:\n- This replaces the previous runtime-class isolation approach with the smaller class-config injection fix for validation.