### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/dingo/model/llm/base_litellm.py
+++ b/dingo/model/llm/base_litellm.py
@@ -43,6 +43,35 @@ class BaseLiteLLM(BaseOpenAI):
         # Use cls.client as an initialisation sentinel (no real client object needed).
         cls.client = True
 
+        # If embedding_config is configured, initialize the embedding client
+        if cls.dynamic_config.embedding_config:
+            from openai import OpenAI
+
+            from dingo.config.input_args import EmbeddingConfigArgs
+
+            embedding_cfg = cls.dynamic_config.embedding_config
+
+            # Handle embedding_config being a dict or object
+            if isinstance(embedding_cfg, dict):
+                embedding_cfg = EmbeddingConfigArgs(**embedding_cfg)
+
+            if not embedding_cfg.api_url:
+                raise ValueError("embedding_config must provide api_url")
+
+            if not embedding_cfg.model:
+                raise ValueError("embedding_config must provide model")
+
+            # Create independent Embedding client
+            cls.embedding_client = OpenAI(
+                api_key=embedding_cfg.key or 'dummy-key',
+                base_url=embedding_cfg.api_url
+            )
+
+            cls.embedding_model = {
+                'model_name': embedding_cfg.model,
+                'client': cls.embedding_client
+            }
+
     @classmethod
     def send_messages(cls, messages: List) -> str:
         import litellm
@@ -66,10 +95,15 @@ class BaseLiteLLM(BaseOpenAI):
             **call_kwargs,
         )
 
-        finish_reason = response.choices[0].finish_reason  # type: ignore[union-attr]
+        if not response.choices:
+            raise ValueError("LiteLLM returned an empty response choices list.")
+
+        choice = response.choices[0]
+        finish_reason = choice.finish_reason  # type: ignore[union-attr]
         if finish_reason == "length":
             raise ExceedMaxTokens(
                 f"Exceed max tokens: {extra_params.get('max_tokens', 4000)}"
             )
 
-        return str(response.choices[0].message.content)  # type: ignore[union-attr]
+        content = choice.message.content  # type: ignore[union-attr]
+        return str(content) if content is not None else ""

--- a/dingo/model/llm/base_litellm.py
+++ b/dingo/model/llm/base_litellm.py
@@ -1,0 +1,75 @@
+from typing import List
+
+from dingo.config.input_args import EvaluatorLLMArgs
+from dingo.model.llm.base_openai import BaseOpenAI
+from dingo.utils.exception import ExceedMaxTokens
+
+
+class BaseLiteLLM(BaseOpenAI):
+    """Base class for LLM evaluators that route through LiteLLM.
+
+    Provides access to 100+ providers (Anthropic, Gemini, Bedrock, Cohere,
+    Mistral, Groq, etc.) via a single unified interface. Inherit from this
+    class instead of BaseOpenAI when you want provider flexibility.
+
+    Model string examples:
+      - "anthropic/claude-3-5-sonnet-20241022"
+      - "gemini/gemini-1.5-pro"
+      - "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
+      - "groq/llama3-8b-8192"
+      - "gpt-4o"  (defaults to OpenAI, same as BaseOpenAI)
+
+    Configuration (via EvaluatorLLMArgs):
+      - model: required, provider-prefixed model string
+      - key: optional, API key (overrides provider env var)
+      - api_url: optional, custom base URL (e.g. LiteLLM proxy URL)
+      - Any extra field is forwarded to litellm.completion() as a kwarg.
+
+    Requires: pip install "dingo-python[litellm]"
+    """
+
+    dynamic_config: EvaluatorLLMArgs = EvaluatorLLMArgs()
+
+    @classmethod
+    def create_client(cls):
+        if not cls.dynamic_config.model:
+            raise ValueError("model cannot be empty in llm config.")
+        try:
+            import litellm  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "litellm is not installed. Run: pip install 'dingo-python[litellm]'"
+            ) from exc
+        # Use cls.client as an initialisation sentinel (no real client object needed).
+        cls.client = True
+
+    @classmethod
+    def send_messages(cls, messages: List) -> str:
+        import litellm
+
+        model_name = cls.dynamic_config.model or ""
+        extra_params = cls.dynamic_config.model_extra or {}
+        cls.validate_config(extra_params)
+
+        call_kwargs: dict = {
+            "drop_params": True,
+            **extra_params,
+        }
+        if cls.dynamic_config.api_url:
+            call_kwargs["api_base"] = cls.dynamic_config.api_url
+        if cls.dynamic_config.key:
+            call_kwargs["api_key"] = cls.dynamic_config.key
+
+        response = litellm.completion(
+            model=model_name,
+            messages=messages,
+            **call_kwargs,
+        )
+
+        finish_reason = response.choices[0].finish_reason  # type: ignore[union-attr]
+        if finish_reason == "length":
+            raise ExceedMaxTokens(
+                f"Exceed max tokens: {extra_params.get('max_tokens', 4000)}"
+            )
+
+        return str(response.choices[0].message.content)  # type: ignore[union-attr]

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,13 @@ requirements = _read_requirements("./requirements/runtime.txt")
 
 agent_requirements = _read_requirements("./requirements/agent.txt")
 hhem_requirements = _read_requirements("./requirements/hhem_integration.txt")
+litellm_requirements = ["litellm>=1.35.0,<2.0"]
 
 extras_require = {
     'agent': agent_requirements,
     'hhem': hhem_requirements,
-    'all': hhem_requirements + agent_requirements,
+    'litellm': litellm_requirements,
+    'all': hhem_requirements + agent_requirements + litellm_requirements,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = _read_requirements("./requirements/runtime.txt")
 
 agent_requirements = _read_requirements("./requirements/agent.txt")
 hhem_requirements = _read_requirements("./requirements/hhem_integration.txt")
-litellm_requirements = ["litellm>=1.35.0,<2.0"]
+litellm_requirements = ["litellm>=1.80.0,<1.87.0"]
 
 extras_require = {
     'agent': agent_requirements,

--- a/test/scripts/model/llm/test_litellm.py
+++ b/test/scripts/model/llm/test_litellm.py
@@ -5,14 +5,16 @@ from unittest import mock
 
 import pytest
 
-from dingo.config.input_args import EvaluatorLLMArgs
-from dingo.model.llm.base_litellm import BaseLiteLLM
-from dingo.utils.exception import ExceedMaxTokens
+pytest.importorskip("litellm", reason="litellm is not installed")
 
+from dingo.config.input_args import EvaluatorLLMArgs  # noqa: E402
+from dingo.model.llm.base_litellm import BaseLiteLLM  # noqa: E402
+from dingo.utils.exception import ExceedMaxTokens  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_provider(**cfg_kwargs) -> type:
     """Return a fresh BaseLiteLLM subclass with an isolated dynamic_config."""
@@ -112,6 +114,20 @@ class TestSendMessages:
         with mock.patch("litellm.completion", return_value=length_resp):
             with pytest.raises(ExceedMaxTokens):
                 P.send_messages([{"role": "user", "content": "hi"}])
+
+    def test_raises_on_empty_choices(self):
+        P = _make_provider(model="gpt-4o")
+        empty_resp = SimpleNamespace(choices=[])
+        with mock.patch("litellm.completion", return_value=empty_resp):
+            with pytest.raises(ValueError, match="empty response choices"):
+                P.send_messages([{"role": "user", "content": "hi"}])
+
+    def test_none_content_returns_empty_string(self):
+        P = _make_provider(model="gpt-4o")
+        none_resp = _stub_response(content=None)
+        with mock.patch("litellm.completion", return_value=none_resp):
+            result = P.send_messages([{"role": "user", "content": "hi"}])
+        assert result == ""
 
 
 # ---------------------------------------------------------------------------

--- a/test/scripts/model/llm/test_litellm.py
+++ b/test/scripts/model/llm/test_litellm.py
@@ -1,0 +1,134 @@
+"""Unit tests for BaseLiteLLM provider."""
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from dingo.config.input_args import EvaluatorLLMArgs
+from dingo.model.llm.base_litellm import BaseLiteLLM
+from dingo.utils.exception import ExceedMaxTokens
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_provider(**cfg_kwargs) -> type:
+    """Return a fresh BaseLiteLLM subclass with an isolated dynamic_config."""
+
+    class _Provider(BaseLiteLLM):
+        prompt = "Evaluate: "
+        dynamic_config = EvaluatorLLMArgs(**cfg_kwargs)
+
+    return _Provider
+
+
+def _stub_response(content='{"score": 1, "reason": "ok"}', finish_reason="stop"):
+    choice = SimpleNamespace(
+        finish_reason=finish_reason,
+        message=SimpleNamespace(content=content),
+    )
+    return SimpleNamespace(choices=[choice])
+
+
+# ---------------------------------------------------------------------------
+# create_client
+# ---------------------------------------------------------------------------
+
+class TestCreateClient:
+    def test_raises_without_model(self):
+        P = _make_provider()
+        with pytest.raises(ValueError, match="model cannot be empty"):
+            P.create_client()
+
+    def test_sets_sentinel_on_success(self):
+        P = _make_provider(model="anthropic/claude-haiku-4-5")
+        P.create_client()
+        assert P.client is True
+
+    def test_raises_import_error_when_litellm_missing(self, monkeypatch):
+        P = _make_provider(model="anthropic/claude-haiku-4-5")
+        monkeypatch.setitem(sys.modules, "litellm", None)  # type: ignore[arg-type]
+        with pytest.raises((ImportError, TypeError)):
+            P.create_client()
+
+
+# ---------------------------------------------------------------------------
+# send_messages
+# ---------------------------------------------------------------------------
+
+class TestSendMessages:
+    def test_dispatches_to_litellm(self):
+        P = _make_provider(model="anthropic/claude-haiku-4-5")
+        msgs = [{"role": "user", "content": "hello"}]
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages(msgs)
+        m.assert_called_once()
+        assert m.call_args.kwargs["model"] == "anthropic/claude-haiku-4-5"
+        assert m.call_args.kwargs["messages"] == msgs
+
+    def test_drop_params_always_true(self):
+        P = _make_provider(model="gpt-4o")
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        assert m.call_args.kwargs.get("drop_params") is True
+
+    def test_api_key_forwarded(self):
+        P = _make_provider(model="gpt-4o", key="sk-test-123")
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        assert m.call_args.kwargs.get("api_key") == "sk-test-123"
+
+    def test_api_base_forwarded_when_url_set(self):
+        P = _make_provider(model="gpt-4o", api_url="https://my-proxy.example.com/v1")
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        assert m.call_args.kwargs.get("api_base") == "https://my-proxy.example.com/v1"
+
+    def test_no_api_key_when_key_not_set(self):
+        P = _make_provider(model="anthropic/claude-haiku-4-5")
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        assert "api_key" not in m.call_args.kwargs
+
+    def test_no_api_base_when_url_not_set(self):
+        P = _make_provider(model="gpt-4o")
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        assert "api_base" not in m.call_args.kwargs
+
+    def test_extra_params_forwarded(self):
+        P = _make_provider(model="gpt-4o", temperature=0.3, max_tokens=500)
+        with mock.patch("litellm.completion", return_value=_stub_response()) as m:
+            P.send_messages([{"role": "user", "content": "hi"}])
+        kw = m.call_args.kwargs
+        assert kw.get("temperature") == 0.3
+        assert kw.get("max_tokens") == 500
+
+    def test_raises_on_length_finish_reason(self):
+        P = _make_provider(model="gpt-4o", max_tokens=10)
+        length_resp = _stub_response(finish_reason="length")
+        with mock.patch("litellm.completion", return_value=length_resp):
+            with pytest.raises(ExceedMaxTokens):
+                P.send_messages([{"role": "user", "content": "hi"}])
+
+
+# ---------------------------------------------------------------------------
+# process_response (inherited from BaseOpenAI)
+# ---------------------------------------------------------------------------
+
+class TestProcessResponse:
+    def test_parses_good_score(self):
+        import json
+        response = json.dumps({"score": 1, "reason": "looks fine"})
+        result = BaseLiteLLM.process_response(response)
+        assert result.status is False
+        assert result.label == ["QUALITY_GOOD"]
+
+    def test_parses_bad_score(self):
+        import json
+        response = json.dumps({"score": 0, "reason": "bad content"})
+        result = BaseLiteLLM.process_response(response)
+        assert result.status is True
+        assert "BaseLiteLLM" in result.label[0]


### PR DESCRIPTION
## Summary

- Adds `BaseLiteLLM` — a drop-in base class for Dingo's LLM evaluators that routes calls through [LiteLLM](https://github.com/BerriAI/litellm), giving access to 100+ providers (Anthropic, Gemini, Bedrock, Groq, Cohere, Mistral, etc.) via a single unified interface
- `litellm` is an optional extra (`pip install "dingo-python[litellm]"`) — base install is unaffected
- All existing evaluators that extend `BaseOpenAI` are untouched; `BaseLiteLLM` is purely additive

## Motivation

Dingo's `BaseOpenAI` evaluators require an OpenAI-compatible `api_url` endpoint. Users who want to run evaluations against Anthropic, Google Gemini, AWS Bedrock, Groq, or any other provider today must either maintain a separate proxy or have no supported path. `BaseLiteLLM` removes that friction — specify a provider-prefixed model string and LiteLLM handles the routing automatically.

## Changes

- `dingo/model/llm/base_litellm.py` — new `BaseLiteLLM` class extending `BaseOpenAI`; overrides `create_client()` and `send_messages()` to use `litellm.completion()` with `drop_params=True`
- `setup.py` — added `litellm>=1.35.0,<2.0` under `extras_require['litellm']` and included it in `'all'`
- `test/scripts/model/llm/test_litellm.py` — 13 unit tests covering dispatch, `drop_params`, key/url forwarding, extra params, length error, and response parsing

## Implementation notes

- **`drop_params=True` by default** — silently drops per-provider-unsupported kwargs (e.g. `seed`, `strict`, `frequency_penalty` fail on Anthropic/Gemini without this)
- **Lazy import** — `litellm` is imported inside method bodies so the base install works without it
- **Sentinel client** — sets `cls.client = True` after init so the `eval()` loop's `if cls.client is None` guard doesn't re-run initialization on every call
- **`api_url` maps to `api_base`** — supports LiteLLM proxy deployments; `key` maps to `api_key`

## Tests

**1. Unit tests:** `pytest test/scripts/model/llm/test_litellm.py -v`

```
test/scripts/model/llm/test_litellm.py::TestCreateClient::test_raises_without_model PASSED
test/scripts/model/llm/test_litellm.py::TestCreateClient::test_sets_sentinel_on_success PASSED
test/scripts/model/llm/test_litellm.py::TestCreateClient::test_raises_import_error_when_litellm_missing PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_dispatches_to_litellm PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_drop_params_always_true PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_api_key_forwarded PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_api_base_forwarded_when_url_set PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_no_api_key_when_key_not_set PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_no_api_base_when_url_not_set PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_extra_params_forwarded PASSED
test/scripts/model/llm/test_litellm.py::TestSendMessages::test_raises_on_length_finish_reason PASSED
test/scripts/model/llm/test_litellm.py::TestProcessResponse::test_parses_good_score PASSED
test/scripts/model/llm/test_litellm.py::TestProcessResponse::test_parses_bad_score PASSED
13 passed in 0.50s
```

Full suite (excluding pyspark which isn't installed in CI without the extras): `543 passed, 27 skipped`

**2. Live E2E against Anthropic (via Azure Foundry):**

```python
from dingo.config.input_args import EvaluatorLLMArgs
from dingo.model.llm.base_litellm import BaseLiteLLM
from dingo.io.input import Data

class LiteLLMSmokeTest(BaseLiteLLM):
    prompt = "Score this text for quality. Return JSON with keys: score (1=good, 0=bad), reason. Text: "
    dynamic_config = EvaluatorLLMArgs(
        model="anthropic/claude-sonnet-4-6",
        key="<ANTHROPIC_API_KEY>",
    )

result = LiteLLMSmokeTest.eval(Data(content="The sky is blue and the sun rises in the east."))
# status: False
# label: ['QUALITY_GOOD']
# reason: ['Clear, factually accurate, and grammatically correct sentence.']
# metric: LiteLLMSmokeTest
```

Full chain verified: `eval()` → `create_client()` → `build_messages()` → `send_messages()` → `litellm.completion()` → Anthropic REST → `process_response()` → `EvalDetail`.

**3. Import syntax check:** `python .github/scripts/check_imports.py` — 158 files checked, all pass.

**4. Pin resolution:** `litellm>=1.35.0,<2.0` resolves cleanly (litellm 1.89.1 is current stable).

## Risk / Compatibility

- Additive only — no existing files changed except `setup.py` extras
- `litellm` stays optional; base install (`dingo-python`) is unaffected
- `drop_params=True` is scoped to `BaseLiteLLM` only; `BaseOpenAI` behavior is unchanged

## Example usage

```python
from dingo.config.input_args import EvaluatorLLMArgs
from dingo.model.llm.base_litellm import BaseLiteLLM
from dingo.model import Model
from dingo.io.input import Data

# Create a custom evaluator backed by any LiteLLM-supported provider
@Model.llm_register("MyLiteLLMEvaluator")
class MyLiteLLMEvaluator(BaseLiteLLM):
    prompt = "Evaluate the quality of the following text. Return JSON {score: 1|0, reason: str}. Text: "
    dynamic_config = EvaluatorLLMArgs(
        model="anthropic/claude-haiku-4-5",   # or gemini/gemini-1.5-flash, groq/llama3-8b-8192, etc.
        key="<YOUR_ANTHROPIC_API_KEY>",
    )

# Or use via SDK config (no code changes needed):
# {"name": "MyLiteLLMEvaluator", "config": {"model": "anthropic/claude-haiku-4-5", "key": "..."}}

result = MyLiteLLMEvaluator.eval(Data(content="Sample text to evaluate."))
print(result.label, result.reason)
```

Install:
```bash
pip install "dingo-python[litellm]"
```
