### PR TITLE
feat: RuleHallucinationHHEM 底层模型改用 MiniCheck-Flan-T5-Large

### DIFF
--- a/dingo/model/rule/rule_hallucination_hhem.py
+++ b/dingo/model/rule/rule_hallucination_hhem.py
@@ -1,14 +1,30 @@
 """
-HHEM-2.1-Open Hallucination Detection Rule
+MiniCheck Hallucination Detection Rule
 
-This module provides integration with Vectara's HHEM-2.1-Open model as a rule-based
-hallucination detection tool for efficient local inference without API costs.
+This module provides local, API-free hallucination (ungrounded-claim) detection
+for RAG-style data by checking whether a response is supported by its context.
 
-Key advantages of HHEM-2.1-Open:
-- Superior performance compared to GPT-3.5/GPT-4 on benchmarks
-- Local inference with <600MB RAM usage
-- Fast processing (~1.5s for 2k tokens on modern CPU)
-- No API costs or rate limits
+Model: `lytang/MiniCheck-Flan-T5-Large` (EMNLP 2024, arXiv:2404.10774).
+
+Why MiniCheck instead of Vectara HHEM-2.1-Open (the original backing model):
+- Stronger grounding accuracy: MiniCheck-Flan-T5-Large scores 75.0 vs HHEM's
+  71.8 on the LLM-AggreFact benchmark (llm-aggrefact.github.io).
+- Robust across transformers versions: MiniCheck is a *standard*
+  `T5ForConditionalGeneration` (config `model_type: t5`, no `auto_map` /
+  `trust_remote_code`). HHEM shipped custom remote code that breaks on
+  transformers >= 4.49 (AttributeError: `all_tied_weights_keys`), which forced
+  a `<4.49` pin. MiniCheck removes that constraint.
+- Still efficient and CPU-friendly (0.8B params), no API costs or rate limits.
+
+The class name is kept as `RuleHallucinationHHEM` for backward compatibility
+(the registered rule id `QUALITY_BAD_HALLUCINATION` and existing configs are
+unaffected).
+
+Inference is replicated faithfully from the official MiniCheck source
+(Liyan06/MiniCheck): input `"predict: " + doc + </s> + claim`, a single-step
+decoder forward, then a 2-way softmax over label token ids [3, 209] where
+index 1 is P(supported). Long documents are split into word chunks and the
+support probability is aggregated by max.
 """
 
 import json
@@ -26,13 +42,17 @@ from dingo.utils import log
 @Model.rule_register("QUALITY_BAD_HALLUCINATION", ["hallucination", "rag"])
 class RuleHallucinationHHEM(BaseRule):
     """
-    HHEM-2.1-Open hallucination detection rule.
+    MiniCheck-based hallucination detection rule.
 
-    Provides efficient local hallucination detection with:
-    - Superior performance than GPT models on benchmarks
-    - Low resource usage (<600MB RAM)
-    - Fast inference (~1.5s for 2k tokens on modern CPU)
-    - No API costs or rate limits
+    Detects ungrounded claims by checking whether the response (content) is
+    supported by the provided context, using `lytang/MiniCheck-Flan-T5-Large`:
+    - Strong grounding accuracy (75.0 on LLM-AggreFact, > HHEM's 71.8)
+    - Standard T5 model -> no transformers version pin, no remote code
+    - Local inference, CPU-friendly, no API costs or rate limits
+
+    Note: the class is still named `RuleHallucinationHHEM` for backward
+    compatibility; the underlying model was upgraded from Vectara HHEM-2.1-Open
+    to MiniCheck.
     """
 
     # Metadata for documentation generation
@@ -40,66 +60,131 @@ class RuleHallucinationHHEM(BaseRule):
         "category": "SFT Data Assessment Metrics",
         "quality_dimension": "HALLUCINATION",
         "metric_name": "RuleHallucinationHHEM",
-        "description": "Uses Vectara's HHEM-2.1-Open model for local hallucination detection by evaluating consistency between response and context",
-        "paper_title": "HHEM-2.1-Open",
-        "paper_url": "https://huggingface.co/vectara/hallucination_evaluation_model",
-        "paper_authors": "Forrest Bao, Miaoran Li, Rogger Luo, Ofer Mendelevitch"
+        "description": "Uses the MiniCheck-Flan-T5-Large model for local hallucination "
+                       "detection by checking whether the response is grounded in the context",
+        "paper_title": "MiniCheck: Efficient Fact-Checking of LLMs on Grounding Documents",
+        "paper_url": "https://arxiv.org/abs/2404.10774",
+        "paper_authors": "Liyan Tang, Philippe Laban, Greg Durrett"
     }
 
+    # CONTENT = the response/claim to verify; CONTEXT = the grounding document.
+    # These are exactly the two inputs MiniCheck needs (claim vs. document), so
+    # they remain the most fitting required fields.
     _required_fields = [RequiredField.CONTENT, RequiredField.CONTEXT]
     dynamic_config = EvaluatorRuleArgs(threshold=0.5)
     model = None
+    tokenizer = None
     _load_lock = Lock()
-    _model_repo_id = "vectara/hallucination_evaluation_model"
+    _model_repo_id = "lytang/MiniCheck-Flan-T5-Large"
+    # MiniCheck flan-t5 inference config (from Liyan06/MiniCheck)
+    _chunk_size = 500        # words per document chunk before max-aggregation
+    _max_input_length = 2048  # tokenizer truncation length
 
     @classmethod
     def load_model(cls):
-        """Load HHEM-2.1-Open model"""
+        """Load the MiniCheck-Flan-T5-Large model and tokenizer."""
         if cls.model is None:
             with cls._load_lock:
                 if cls.model is not None:
                     return
                 try:
-                    from huggingface_hub import snapshot_download
-                    from transformers import AutoModelForSequenceClassification
+                    from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
-                    log.info("Loading HHEM-2.1-Open model...")
+                    log.info("Loading MiniCheck-Flan-T5-Large model...")
+                    # MiniCheck is a standard T5 model: no trust_remote_code
+                    # needed, and it loads on any modern transformers version.
                     try:
-                        model_path = snapshot_download(
-                            repo_id=cls._model_repo_id,
-                            repo_type="model",
-                            local_files_only=True,
+                        # Prefer offline / cached load first
+                        cls.model = AutoModelForSeq2SeqLM.from_pretrained(
+                            cls._model_repo_id, local_files_only=True,
+                        )
+                        cls.tokenizer = AutoTokenizer.from_pretrained(
+                            cls._model_repo_id, local_files_only=True,
                         )
                     except Exception:
-                        model_path = snapshot_download(
-                            repo_id=cls._model_repo_id,
-                            repo_type="model",
+                        # Fall back to downloading from the Hub
+                        cls.model = AutoModelForSeq2SeqLM.from_pretrained(
+                            cls._model_repo_id,
                         )
-
-                    cls.model = AutoModelForSequenceClassification.from_pretrained(
-                        model_path,
-                        trust_remote_code=True,
-                        local_files_only=True,
-                    )
-                    log.info("✅ HHEM-2.1-Open model loaded successfully")
+                        cls.tokenizer = AutoTokenizer.from_pretrained(
+                            cls._model_repo_id,
+                        )
+                    cls.model.eval()
+                    log.info("✅ MiniCheck-Flan-T5-Large model loaded successfully")
 
                 except ImportError:
                     raise ImportError(
-                        "transformers and huggingface_hub are required for HHEM model. "
-                        "Install with: pip install transformers huggingface_hub"
+                        "transformers is required for the MiniCheck model. "
+                        "Install with: pip install transformers torch sentencepiece"
                     )
                 except Exception as e:
                     raise RuntimeError(
-                        "Failed to load HHEM model. "
+                        "Failed to load MiniCheck model. "
                         "The first run requires network access to download "
                         f"'{cls._model_repo_id}', or a populated Hugging Face cache. "
                         f"Original error: {e}"
                     ) from e
 
+    @staticmethod
+    def _chunk_document(document: str, chunk_size: int) -> List[str]:
+        """Split a document into consecutive chunks of ~chunk_size words.
+
+        Lightweight, dependency-free approximation of MiniCheck's sentence-based
+        chunking (the official code uses nltk sent_tokenize). RAG contexts
+        usually fit in a single chunk, so this rarely changes behavior; long
+        documents are still split so no content is silently truncated.
+        """
+        text = document.strip()
+        if not text:
+            return []
+        words = text.split()
+        if len(words) <= chunk_size:
+            return [text]
+        return [" ".join(words[i:i + chunk_size])
+                for i in range(0, len(words), chunk_size)]
+
+    @classmethod
+    def _support_prob(cls, document: str, claim: str) -> float:
+        """Probability that `claim` is supported by `document` (0=unsupported, 1=supported).
+
+        Faithful replication of the official MiniCheck flan-t5 inference:
+          input   = "predict: " + doc_chunk + tokenizer.eos_token + claim
+          forward = model(input_ids, attention_mask, decoder_input_ids=zeros(B,1))
+          logits  = outputs.logits.squeeze(1)
+          probs   = softmax(logits[:, [3, 209]])   # 3=no support, 209=support
+          support = probs[:, 1]
+        Aggregated by max over document chunks.
+        """
+        import torch
+
+        chunks = cls._chunk_document(document, cls._chunk_size) or [""]
+        texts = ["predict: " + cls.tokenizer.eos_token.join([chunk, claim])
+                 for chunk in chunks]
+        enc = cls.tokenizer(
+            texts,
+            max_length=cls._max_input_length,
+            truncation=True,
+            padding=True,
+            return_tensors="pt",
+        )
+        decoder_input_ids = torch.zeros(
+            (enc["input_ids"].size(0), 1), dtype=torch.long)
+        with torch.no_grad():
+            logits = cls.model(
+                input_ids=enc["input_ids"],
+                attention_mask=enc["attention_mask"],
+                decoder_input_ids=decoder_input_ids,
+            ).logits.squeeze(1)
+        # Label token ids from the official MiniCheck code: 3=no support, 209=support
+        label_probs = torch.nn.functional.softmax(
+            logits[:, torch.tensor([3, 209])], dim=-1)
+        support_probs = label_probs[:, 1]
+        return float(support_probs.max().item())
+
     @classmethod
     def eval(cls, input_data: Data) -> EvalDetail:
         """
-        Evaluate hallucination using HHEM-2.1-Open model.
+        Evaluate hallucination using the MiniCheck-Flan-T5-Large model.
 
         Args:
             input_data: Data object containing content and context
@@ -118,9 +203,9 @@ class RuleHallucinationHHEM(BaseRule):
                 result.status = True
                 # result.type = cls.metric_type
                 # result.name = "MISSING_CONTEXT"
-                # result.reason = ["Context is required for HHEM hallucination detection but was not provided"]
+                # result.reason = ["Context is required for hallucination detection but was not provided"]
                 result.label = [f"{cls.metric_type}.MISSING_CONTEXT"]
-                result.reason = ["Context is required for HHEM hallucination detection but was not provided"]
+                result.reason = ["Context is required for hallucination detection but was not provided"]
                 return result
         else:
             contexts = input_data.context
@@ -142,20 +227,15 @@ class RuleHallucinationHHEM(BaseRule):
 
         response = input_data.content
 
-        # Create premise-hypothesis pairs for HHEM evaluation
-        # Format: (premise, hypothesis) where premise=context, hypothesis=response
-        pairs = [(context, response) for context in context_list]
-
         try:
-            # Use HHEM model's official predict() method
-            # This returns consistency scores (0=hallucinated, 1=consistent)
-            scores = cls.model.predict(pairs)
+            # Score each context with MiniCheck: P(response supported by context).
+            # support prob in [0,1], 1 = fully grounded / consistent.
+            consistency_scores = [
+                cls._support_prob(context, response) for context in context_list
+            ]
 
-            # Convert to list if tensor
-            consistency_scores = scores.tolist() if hasattr(scores, 'tolist') else list(scores)
-
-            # HHEM returns consistency scores (0=hallucinated, 1=consistent)
-            # We convert to hallucination scores (1=hallucinated, 0=consistent)
+            # Convert support probabilities to hallucination scores
+            # (1 = hallucinated / ungrounded, 0 = consistent)
             hallucination_scores = [1.0 - score for score in consistency_scores]
 
             # Average hallucination score across all contexts
@@ -174,7 +254,7 @@ class RuleHallucinationHHEM(BaseRule):
 
                 # Generate detailed analysis
                 analysis_parts = [
-                    f"🔍 HHEM-2.1-Open 幻觉检测分析",
+                    "🔍 MiniCheck 幻觉检测分析",
                     f"📊 平均幻觉分数: {avg_hallucination_score:.3f} (阈值: {cls.dynamic_config.threshold})",
                     f"📝 评估上下文数量: {len(context_list)}"
                 ]
@@ -209,7 +289,7 @@ class RuleHallucinationHHEM(BaseRule):
                     f"🚨 结论: 检测到幻觉 (分数 {avg_hallucination_score:.3f} > 阈值 {cls.dynamic_config.threshold})",
                     "   回答与提供的上下文存在显著矛盾",
                     "",
-                    "💡 模型信息: 使用 Vectara HHEM-2.1-Open (本地推理)"
+                    "💡 模型信息: 使用 MiniCheck-Flan-T5-Large (本地推理)"
                 ])
 
                 # result.reason = ["\n".join(analysis_parts)]
@@ -222,11 +302,11 @@ class RuleHallucinationHHEM(BaseRule):
 
                 # Generate analysis for non-hallucination case
                 analysis = (
-                    f"✅ HHEM-2.1-Open 幻觉检测分析\n"
+                    f"✅ MiniCheck 幻觉检测分析\n"
                     f"📊 平均幻觉分数: {avg_hallucination_score:.3f} (阈值: {cls.dynamic_config.threshold})\n"
                     f"📝 评估上下文数量: {len(context_list)}\n"
                     f"🎉 结论: 未检测到幻觉，回答与上下文基本一致\n"
-                    f"💡 模型信息: 使用 Vectara HHEM-2.1-Open (本地推理)"
+                    f"💡 模型信息: 使用 MiniCheck-Flan-T5-Large (本地推理)"
                 )
                 # result.reason = [analysis]
                 result.reason = [analysis]
@@ -238,10 +318,10 @@ class RuleHallucinationHHEM(BaseRule):
             result = EvalDetail(metric=cls.__name__)
             result.status = True
             # result.type = cls.metric_type
-            # result.name = "HHEM_ERROR"
-            # result.reason = [f"HHEM model inference failed: {str(e)}"]
-            result.label = [f"{cls.metric_type}.HHEM_ERROR"]
-            result.reason = [f"HHEM model inference failed: {str(e)}"]
+            # result.name = "MINICHECK_ERROR"
+            # result.reason = [f"MiniCheck model inference failed: {str(e)}"]
+            result.label = [f"{cls.metric_type}.MINICHECK_ERROR"]
+            result.reason = [f"MiniCheck model inference failed: {str(e)}"]
             return result
 
     @classmethod
@@ -261,7 +341,7 @@ class RuleHallucinationHHEM(BaseRule):
             # "assessment_type": result.type,
             # "assessment_name": result.name,
             "analysis": result.reason[0] if result.reason else "",
-            "model_info": "HHEM-2.1-Open (Vectara)"
+            "model_info": "MiniCheck-Flan-T5-Large"
         }
 
     @classmethod

--- a/docs/hallucination_detection_guide.md
+++ b/docs/hallucination_detection_guide.md
@@ -1,6 +1,8 @@
 # Dingo Hallucination Detection - Complete Guide
 
-This guide introduces how to use integrated hallucination detection features in Dingo, supporting two detection methods: **HHEM-2.1-Open local model** (recommended) and **GPT-based cloud detection**.
+This guide introduces how to use integrated hallucination detection features in Dingo, supporting two detection methods: **MiniCheck local model** (recommended) and **GPT-based cloud detection**.
+
+> Note: the local rule is still named `RuleHallucinationHHEM` for backward compatibility, but its underlying model was upgraded from Vectara HHEM-2.1-Open to `lytang/MiniCheck-Flan-T5-Large` (a standard T5 grounding checker, arXiv:2404.10774).
 
 ## 🎯 Feature Overview
 
@@ -57,7 +59,7 @@ context = {"passages": ["Context 1", "Context 2"]}
 
 ## 🚀 Quick Start
 
-### Method 1: HHEM-2.1-Open Local Model (Recommended ⭐)
+### Method 1: MiniCheck Local Model (Recommended ⭐)
 
 **Advantages**:
 - ✅ Fast speed
@@ -72,7 +74,7 @@ context = {"passages": ["Context 1", "Context 2"]}
 pip install dingo-python[hhem]
 
 # Or install dependencies manually
-pip install sentence-transformers torch
+pip install transformers torch sentencepiece
 ```
 
 **Usage**:
@@ -82,7 +84,7 @@ from dingo.config.input_args import EvaluatorRuleArgs
 from dingo.io.input import Data
 from dingo.model.rule.rule_hallucination_hhem import RuleHallucinationHHEM
 
-# Configure (first run will auto-download model ~400MB)
+# Configure (first run will auto-download model ~3GB, flan-t5-large)
 RuleHallucinationHHEM.dynamic_config = EvaluatorRuleArgs(
     threshold=0.5  # Hallucination threshold, higher = stricter
 )
@@ -208,7 +210,7 @@ print(f"Pass rate: {summary.score}%")
 ### Threshold Adjustment
 
 ```python
-# Method 1: Rule-based (HHEM)
+# Method 1: Rule-based (MiniCheck)
 RuleHallucinationHHEM.dynamic_config = EvaluatorRuleArgs(
     threshold=0.5  # Range: 0.0-1.0
 )
@@ -227,38 +229,33 @@ LLMHallucination.dynamic_config = EvaluatorLLMArgs(
 - **General scenarios** (Q&A systems): 0.5-0.6
 - **Loose scenarios** (creative content): 0.7-0.8
 
-### Device Selection (HHEM Only)
+### Device (MiniCheck)
+
+By default the MiniCheck model is loaded and runs on **CPU**, which is
+sufficient for the 0.8B flan-t5-large checkpoint. If you want to run inference
+on GPU, move the loaded model to your device after the first load:
 
 ```python
-# Auto-select (default: uses GPU if available)
-RuleHallucinationHHEM.dynamic_config = EvaluatorRuleArgs()
-
-# Force CPU
-import torch
-RuleHallucinationHHEM.device = "cpu"
-
-# Force GPU
-RuleHallucinationHHEM.device = "cuda"
-
-# Specific GPU
-RuleHallucinationHHEM.device = "cuda:0"
+# Trigger a load, then move to GPU
+RuleHallucinationHHEM.load_model()
+RuleHallucinationHHEM.model = RuleHallucinationHHEM.model.to("cuda")
 ```
 
 ## 📈 Performance Comparison
 
-| Feature | HHEM-2.1-Open | GPT-based |
+| Feature | MiniCheck (local) | GPT-based |
 |---------|---------------|-----------|
-| **Speed** | Fast (~50ms/sample) | Slower (~1-2s/sample) |
+| **Speed** | Fast (~200-500ms/sample on CPU) | Slower (~1-2s/sample) |
 | **Cost** | Free | API costs |
-| **Accuracy** | High (F1: 0.84) | Very High |
+| **Accuracy** | High (75.0 balanced acc. on LLM-AggreFact) | Very High |
 | **Privacy** | Local, secure | Data sent to API |
-| **Deployment** | Needs model download (~400MB) | Needs API key |
+| **Deployment** | Needs model download (~3GB) | Needs API key |
 | **Offline** | ✅ Supported | ❌ Requires network |
 
 **Recommendations**:
-- **Production environment**: HHEM-2.1-Open (fast, free, private)
+- **Production environment**: MiniCheck (fast, free, private)
 - **High-precision scenarios**: GPT-based (highest accuracy)
-- **Offline scenarios**: HHEM-2.1-Open (can run completely offline)
+- **Offline scenarios**: MiniCheck (can run completely offline)
 
 ## 🌟 Best Practices
 
@@ -321,21 +318,23 @@ data = Data(
 
 ## ❓ FAQ
 
-### Q1: HHEM vs GPT-based, which to choose?
+### Q1: MiniCheck vs GPT-based, which to choose?
 
-- **Production/large-scale**: HHEM (fast, free, private)
+- **Production/large-scale**: MiniCheck (fast, free, private)
 - **High-precision evaluation**: GPT-based (highest accuracy, but has costs)
-- **Offline scenarios**: HHEM (can run completely offline)
+- **Offline scenarios**: MiniCheck (can run completely offline)
 
-### Q2: Why does HHEM download model on first run?
+### Q2: Why does the local rule download a model on first run?
 
-HHEM uses Sentence-Transformers model (~400MB), auto-downloads and caches on first run. Subsequent runs load directly from cache, no re-download needed.
+The local rule uses the `lytang/MiniCheck-Flan-T5-Large` model (~3GB),
+auto-downloads and caches on first run. Subsequent runs load directly from
+cache, no re-download needed.
 
 ### Q3: What if model download fails?
 
 ```bash
 # Manually download
-huggingface-cli download vectara/hallucination_evaluation_model --local-dir ~/.cache/huggingface/hub/models--vectara--hallucination_evaluation_model
+hf download lytang/MiniCheck-Flan-T5-Large
 
 # Or use mirror
 export HF_ENDPOINT=https://hf-mirror.com
@@ -352,7 +351,7 @@ export HF_ENDPOINT=https://hf-mirror.com
 
 - [RAG Evaluation Metrics Guide](rag_evaluation_metrics.md)
 - [Factuality Assessment Guide](factuality_assessment_guide.md)
-- [HHEM Paper](https://arxiv.org/abs/2406.09053)
+- [MiniCheck Paper](https://arxiv.org/abs/2404.10774)
 
 ## 📝 Example Scenarios
 

--- a/docs/hallucination_guide.md
+++ b/docs/hallucination_guide.md
@@ -1,6 +1,8 @@
 # Dingo 幻觉检测功能完整指南
 
-本指南介绍如何在 Dingo 中使用集成的幻觉检测功能，支持两种检测方案：**HHEM-2.1-Open 本地模型**（推荐）和 **GPT-based 云端检测**。
+本指南介绍如何在 Dingo 中使用集成的幻觉检测功能，支持两种检测方案：**MiniCheck 本地模型**（推荐）和 **GPT-based 云端检测**。
+
+> 说明：本地规则仍沿用类名 `RuleHallucinationHHEM`（保持向后兼容），但底层模型已从 Vectara HHEM-2.1-Open 升级为 `lytang/MiniCheck-Flan-T5-Large`（标准 T5 事实核查模型，arXiv:2404.10774）。相比 HHEM，MiniCheck 在 LLM-AggreFact 基准上更强（75.0 vs 71.8），且为标准 T5，不再受 transformers 版本限制。
 
 ## 🎯 功能概述
 
@@ -58,18 +60,18 @@ context = "单个参考上下文"
 
 ## 🚀 快速开始
 
-### 方法一：HHEM-2.1-Open 本地模型（推荐）
+### 方法一：MiniCheck 本地模型（推荐）
 
 #### 安装依赖
 ```bash
-pip install transformers torch
+pip install transformers torch sentencepiece
 # 或使用专门的依赖文件
 pip install -r requirements/hhem_integration.txt
 ```
 
 #### 模型下载与镜像
 
-首次运行会自动从 Hugging Face 下载 HHEM-2.1-Open 模型（约 400MB），之后从本地缓存加载，无需重复下载。
+首次运行会自动从 Hugging Face 下载 `lytang/MiniCheck-Flan-T5-Large` 模型（约 3GB，flan-t5-large），之后从本地缓存加载，无需重复下载。
 
 如果无法访问 `huggingface.co`（如国内网络），可在运行前设置镜像环境变量，让下载走 [hf-mirror.com](https://hf-mirror.com)：
 
@@ -78,7 +80,7 @@ pip install -r requirements/hhem_integration.txt
 export HF_ENDPOINT=https://hf-mirror.com
 ```
 
-> 说明：Dingo 不会强制修改该变量，以免影响能直连官网的环境（如 CI）；是否使用镜像由你自行控制。也可用 `huggingface-cli download vectara/hallucination_evaluation_model` 提前手动下载。
+> 说明：Dingo 不会强制修改该变量，以免影响能直连官网的环境（如 CI）；是否使用镜像由你自行控制。也可用 `hf download lytang/MiniCheck-Flan-T5-Large` 提前手动下载。
 
 #### 基本使用
 
@@ -140,7 +142,7 @@ print(f"详细原因: {result.reason[0]}")  # 包含幻觉分数等详细信息
 
 ## 📊 批量数据集评估
 
-### 使用 HHEM-2.1-Open（本地，免费）
+### 使用 MiniCheck 本地模型（本地，免费）
 
 ```python
 from dingo.config import InputArgs
@@ -159,7 +161,7 @@ input_data = {
         }
     },
     "executor": {
-        "rule_list": ["RuleHallucinationHHEM"],  # Use HHEM rule instead of LLM
+        "rule_list": ["RuleHallucinationHHEM"],  # 使用本地 MiniCheck 规则替代 LLM
         "result_save": {
             "bad": True,
             "good": True  # Also save good examples for comparison
@@ -178,7 +180,7 @@ input_args = InputArgs(**input_data)
 executor = Executor.exec_map["local"](input_args)
 result = executor.execute()
 
-print(f"HHEM 幻觉检测完成: 发现 {result.bad_count}/{result.total_count} 个问题")
+print(f"MiniCheck 幻觉检测完成: 发现 {result.bad_count}/{result.total_count} 个问题")
 ```
 
 ### 使用 GPT（在线，需要 API）
@@ -231,7 +233,7 @@ print(f"GPT 幻觉检测完成: 发现 {result.bad_count}/{result.total_count} �
 
 ```python
 # 方式1: 直接设置类属性
-RuleHallucinationHHEM.dynamic_config.threshold = 0.3  # HHEM 更严格的检测
+RuleHallucinationHHEM.dynamic_config.threshold = 0.3  # MiniCheck 更严格的检测
 LLMHallucination.threshold = 0.3      # GPT 更严格的检测
 
 # 方式2: 通过配置文件
@@ -261,7 +263,7 @@ LLMHallucination.threshold = 0.3      # GPT 更严格的检测
 ### 性能优化配置
 
 ```python
-# HHEM 批量处理优化
+# MiniCheck 批量处理优化
 RuleHallucinationHHEM.load_model()  # 预加载模型
 results = RuleHallucinationHHEM.batch_evaluate(data_list)  # 批量更高效
 
@@ -319,16 +321,19 @@ result.reason           # List[str]: 详细分析原因（包含幻觉分数信�
 
 ### 典型输出示例
 
-#### HHEM 输出示例
+#### MiniCheck 输出示例
 ```
-HHEM 幻觉分数: 0.650 (阈值: 0.500)
-处理了 2 个上下文对：
+🔍 MiniCheck 幻觉检测分析
+📊 平均幻觉分数: 0.350 (阈值: 0.500)
+📝 评估上下文数量: 2
+❌ 发现 1 个潜在矛盾:
+  1. 上下文: "爱因斯坦在1921年获得诺贝尔奖。"
+     一致性分数: 0.350, 幻觉分数: 0.650
+✅ 1 个上下文与回答一致:
   1. 上下文: "爱因斯坦因发现光电效应获得诺贝尔奖。"
-     一致性: 0.95 → 幻觉分数: 0.05
-  2. 上下文: "爱因斯坦在1921年获得诺贝尔奖。"
-     一致性: 0.35 → 幻觉分数: 0.65
-平均幻觉分数: 0.350
-❌ 检测到幻觉: 超过阈值 0.500
+     一致性分数: 0.950, 幻觉分数: 0.050
+🚨 结论: 检测到幻觉 (分数 0.350 > 阈值 0.500)
+💡 模型信息: 使用 MiniCheck-Flan-T5-Large (本地推理)
 ```
 
 #### GPT 输出示例
@@ -366,7 +371,7 @@ HHEM 幻觉分数: 0.650 (阈值: 0.500)
 ### 1. RAG 系统质量监控
 
 ```python
-# 实时基于RAG监控回答质量（使用本地HHEM）
+# 实时基于RAG监控回答质量（使用本地 MiniCheck）
 def monitor_rag_response(question, generated_answer, retrieved_docs):
     data = Data(
         data_id=f"rag_{timestamp}",
@@ -376,7 +381,6 @@ def monitor_rag_response(question, generated_answer, retrieved_docs):
     )
 
     result = RuleHallucinationHHEM.eval(data)  # 本地、快速、免费
-
     if result.status:
         logger.warning(f"检测到幻觉: {result.reason[0]}")
         # 触发人工审核或回答重生成
@@ -385,7 +389,7 @@ def monitor_rag_response(question, generated_answer, retrieved_docs):
 ### 2. SFT 数据集预处理
 
 ```python
-# 训练前检查SFT数据质量（批量处理使用HHEM）
+# 训练前检查SFT数据质量（批量处理使用 MiniCheck）
 input_data = {
     "input_path": "sft_training_data.jsonl",
     "custom_config": {
@@ -404,7 +408,7 @@ def filter_hallucinated_responses(responses_with_context):
 
     for item in responses_with_context:
         data = Data(**item)
-        # 使用本地HHEM进行快速检测
+        # 使用本地 MiniCheck 进行快速检测
         result = RuleHallucinationHHEM.eval(data)
 
         if not result.status:  # 无幻觉
@@ -424,7 +428,7 @@ class RAGWithHallucinationDetection:
         self.retriever = retriever
         self.llm = llm
         self.detector = hallucination_detector
-        # 预加载HHEM模型以提高性能
+        # 预加载 MiniCheck 模型以提高性能
         self.detector.load_model()
 
     def generate_answer(self, question):
@@ -486,13 +490,13 @@ dingo/
 │   ├── llm/
 │   │   └── llm_hallucination.py            # GPT-based 检测（DeepEval风格）
 │   ├── rule/
-│   │   └── rule_hallucination_hhem.py      # HHEM-2.1-Open 集成
+│   │   └── rule_hallucination_hhem.py      # MiniCheck-Flan-T5-Large 集成
 │   ├── prompt/prompt_hallucination.py       # GPT 提示词模板
 │   └── response/response_hallucination.py   # 响应数据结构
 ├── io/input/Data.py                         # 扩展Data类支持context
 ├── examples/hallucination/                  # 使用示例
-│   ├── sdk_rule_hhem_detection.py          # Rule-based HHEM 使用示例
+│   ├── sdk_rule_hhem_detection.py          # Rule-based MiniCheck 使用示例
 │   ├── sdk_hallucination_detection.py      # GPT 使用示例
 │   └── dataset_hallucination_evaluation.py # 批量评估示例
-└── requirements/hhem_integration.txt        # HHEM 依赖
+└── requirements/hhem_integration.txt        # MiniCheck 依赖
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ This document provides comprehensive information about all quality metrics used 
 | `LLMText3HHarmless` | LLMText3HHarmless | Checks if responses avoid harmful content, discriminatory language, and dangerous assistance | [Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback](https://arxiv.org/pdf/2204.05862) (Bai et al., 2022) | [📊 See Results](eval/prompt/qa_data_evaluated_by_3h.md) | N/A |
 | `LLMText3HHelpful` | LLMText3HHelpful | Assesses if responses address questions directly and follow instructions appropriately | [Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback](https://arxiv.org/pdf/2204.05862) (Bai et al., 2022) | [📊 See Results](eval/prompt/qa_data_evaluated_by_3h.md) | N/A |
 | `LLMText3HHonest` | LLMText3HHonest | Evaluates if responses provide accurate information without fabrication or deception | [Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback](https://arxiv.org/pdf/2204.05862) (Bai et al., 2022) | [📊 See Results](eval/prompt/qa_data_evaluated_by_3h.md) | N/A |
-| `QUALITY_BAD_HALLUCINATION` | RuleHallucinationHHEM | Uses Vectara's HHEM-2.1-Open model for local hallucination detection by evaluating consistency between response and c... | [HHEM-2.1-Open](https://huggingface.co/vectara/hallucination_evaluation_model) (Forrest Bao, Miaoran Li, Rogger Luo, Ofer Mendelevitch) | N/A | N/A |
+| `QUALITY_BAD_HALLUCINATION` | RuleHallucinationHHEM | Uses the MiniCheck-Flan-T5-Large model for local hallucination detection by checking whether the response is grounded... | [MiniCheck: Efficient Fact-Checking of LLMs on Grounding Documents](https://arxiv.org/abs/2404.10774) (Liyan Tang, Philippe Laban, Greg Durrett) | N/A | N/A |
 
 ### Classification Metrics
 
@@ -144,7 +144,7 @@ This document provides comprehensive information about all quality metrics used 
 
 | Type | Metric | Description | Paper Source | Evaluation Results | Examples |
 |------|--------|-------------|--------------|-------------------|----------|
-| `QUALITY_BAD_EFFECTIVENESS` | RuleMetadataSimilarity, RuleAuthorFieldValidation, RuleQuanliangFieldValidation, RuleSourceFieldValidation | 检查元数据字段与基准数据的相似度匹配，阈值默认为0.6; Validate OpenAlex author fields and report invalid fields; Validate Quanliang metadata f... | Internal Implementation | N/A | N/A |
+| `QUALITY_BAD_EFFECTIVENESS` | RuleMetadataSimilarity, RuleSourceFieldValidation, RuleQuanliangFieldValidation, RuleAuthorFieldValidation | 检查元数据字段与基准数据的相似度匹配，阈值默认为0.6; Validate OpenAlex source fields and report invalid fields; Validate Quanliang metadata f... | Internal Implementation | N/A | N/A |
 
 ### Rule-Based RESUME Quality Metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -144,7 +144,7 @@ This document provides comprehensive information about all quality metrics used 
 
 | Type | Metric | Description | Paper Source | Evaluation Results | Examples |
 |------|--------|-------------|--------------|-------------------|----------|
-| `QUALITY_BAD_EFFECTIVENESS` | RuleMetadataSimilarity, RuleSourceFieldValidation, RuleQuanliangFieldValidation, RuleAuthorFieldValidation | 检查元数据字段与基准数据的相似度匹配，阈值默认为0.6; Validate OpenAlex source fields and report invalid fields; Validate Quanliang metadata f... | Internal Implementation | N/A | N/A |
+| `QUALITY_BAD_EFFECTIVENESS` | RuleMetadataSimilarity, RuleAuthorFieldValidation, RuleQuanliangFieldValidation, RuleSourceFieldValidation | 检查元数据字段与基准数据的相似度匹配，阈值默认为0.6; Validate OpenAlex author fields and report invalid fields; Validate Quanliang metadata f... | Internal Implementation | N/A | N/A |
 
 ### Rule-Based RESUME Quality Metrics
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,7 +28,7 @@ The specific rules for each quality metric are as follows:
 | RuleEnterAndSpace | EFFECTIVENESS | Check abnormal combinations of line breaks and spaces. | |
 | RuleEnterMore | EFFECTIVENESS | Check whether content has excessive consecutive line breaks. | |
 | RuleEnterRatioMore | EFFECTIVENESS | Check whether the line-break ratio is excessive. | |
-| RuleHallucinationHHEM | HALLUCINATION | Detect hallucinations with HHEM-2.1-Open. | |
+| RuleHallucinationHHEM | HALLUCINATION | Detect ungrounded claims with MiniCheck-Flan-T5-Large (checks whether the response is supported by the context). | |
 | RuleHeadWordAr | RELEVANCE | Check Arabic content for irrelevant source information. | |
 | RuleHeadWordCs | RELEVANCE | Check Czech content for irrelevant source information. | |
 | RuleHeadWordHu | RELEVANCE | Check Hungarian content for irrelevant source information. | |

--- a/examples/hallucination/sdk_rule_hhem_detection.py
+++ b/examples/hallucination/sdk_rule_hhem_detection.py
@@ -1,15 +1,19 @@
 """
-Dingo Rule-based HHEM-2.1-Open Hallucination Detection Example
+Dingo Rule-based MiniCheck Hallucination Detection Example
 
-This example demonstrates how to use the HHEM-2.1-Open model as a rule-based
-hallucination detection tool for efficient local inference without API costs.
+This example demonstrates how to use the RuleHallucinationHHEM rule (backed by
+the MiniCheck-Flan-T5-Large model) as a local, API-free tool for detecting
+ungrounded claims — i.e. whether a response is supported by its context.
 
-Rule-based HHEM offers:
+Rule-based MiniCheck offers:
 - Better architecture fit (rules vs LLM for deterministic local models)
-- Superior performance than GPT-3.5 and GPT-4 on benchmarks
-- Local inference with <600MB RAM usage
-- Fast processing (~1.5s for 2k tokens on modern CPU)
-- No API costs or rate limits
+- Strong grounding accuracy (75.0 on LLM-AggreFact, > HHEM's 71.8)
+- Standard T5 model — no transformers version pin, no remote code
+- Local inference, no API costs or rate limits
+
+Note: the rule/class is still named RuleHallucinationHHEM for backward
+compatibility; the underlying model was upgraded from Vectara HHEM-2.1-Open
+to MiniCheck.
 """
 
 from dingo.io.input import Data
@@ -35,7 +39,7 @@ def example_1_basic_rule_hhem_detection():
 
     print(f"Error Status: {result.status}")  # True = hallucination detected, False = no hallucination
     print(f"Label: {result.label}")
-    print(f"HHEM Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
+    print(f"Hallucination Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
     print(f"Threshold: {RuleHallucinationHHEM.dynamic_config.threshold}")
     print("\nDetailed Analysis:")
     print(result.reason[0] if result.reason else "N/A")
@@ -61,7 +65,7 @@ def example_2_no_hallucination_rule():
 
     print(f"Error Status: {result.status}")  # True = hallucination detected, False = no hallucination
     print(f"Label: {result.label}")
-    print(f"HHEM Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
+    print(f"Hallucination Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
     print("\nDetailed Analysis:")
     print(result.reason[0] if result.reason else "N/A")
     print()
@@ -89,7 +93,7 @@ def example_3_complex_scenario_rule():
 
     print(f"Error Status: {result.status}")  # True = hallucination detected, False = no hallucination
     print(f"Label: {result.label}")
-    print(f"HHEM Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
+    print(f"Hallucination Score: {f'{result.score:.3f}' if result.score is not None else 'N/A'}")
     print("\nDetailed Analysis:")
     print(result.reason[0] if result.reason else "N/A")
     print()
@@ -204,27 +208,26 @@ def example_7_performance_benchmark_rule():
     result = RuleHallucinationHHEM.eval(data)
     end_time = time.time()
 
-    print(f"Rule-based HHEM Inference Time: {end_time - start_time:.3f} seconds")
+    print(f"Rule-based MiniCheck Inference Time: {end_time - start_time:.3f} seconds")
     print(f"Result: Error={result.status}, Score={f'{result.score:.3f}' if result.score is not None else 'N/A'}")
-    print(f"Model Info: Local HHEM-2.1-Open (Rule-based)")
+    print(f"Model Info: Local MiniCheck-Flan-T5-Large (Rule-based)")
     print()
 
 
 if __name__ == "__main__":
-    print("🔍 Dingo Rule-based HHEM-2.1-Open Hallucination Detection Examples")
+    print("🔍 Dingo Rule-based MiniCheck Hallucination Detection Examples")
     print("=" * 70)
     print()
 
-    print("💡 Rule-based HHEM-2.1-Open Advantages:")
+    print("💡 Rule-based MiniCheck Advantages:")
     print("- Better architecture: Rules for deterministic local models")
     print("- Local inference (no API costs)")
-    print("- High performance (better than GPT-3.5/GPT-4 on benchmarks)")
-    print("- Low resource usage (<600MB RAM)")
-    print("- Fast inference (~1.5s for 2k tokens)")
+    print("- Strong grounding accuracy (75.0 on LLM-AggreFact, > HHEM's 71.8)")
+    print("- Standard T5 model (no transformers version pin, no remote code)")
     print()
 
-    print("⚠️  First run will download the model (~400MB)")
-    print("⚠️  Requires: pip install transformers")
+    print("⚠️  First run will download the model (~3GB, flan-t5-large)")
+    print("⚠️  Requires: pip install transformers torch sentencepiece")
     print()
 
     try:
@@ -236,11 +239,11 @@ if __name__ == "__main__":
         example_6_threshold_comparison_rule()
         example_7_performance_benchmark_rule()
 
-        print("🎉 All Rule-based HHEM examples completed successfully!")
+        print("🎉 All Rule-based MiniCheck examples completed successfully!")
 
     except ImportError as e:
         print(f"❌ Import Error: {e}")
-        print("Please install required dependencies: pip install transformers")
+        print("Please install required dependencies: pip install transformers torch sentencepiece")
     except Exception as e:
         print(f"❌ Error: {e}")
         print("Please check your setup and try again")
@@ -248,8 +251,7 @@ if __name__ == "__main__":
     print()
     print("📈 Rule-based vs LLM-based Comparison:")
     print("- Architecture: Rule-based (✓) vs LLM-based (for API models)")
-    print("- Performance: HHEM-2.1 > GPT-4 > GPT-3.5")
+    print("- Accuracy: MiniCheck competitive with much larger LLM fact-checkers")
     print("- Cost: Rule-based (Free) vs LLM-based (API costs)")
-    print("- Speed: Rule-based (~1.5s) vs LLM-based (3-10s)")
     print("- Privacy: Rule-based (Local) vs LLM-based (Cloud)")
-    print("- Resource: Rule-based (<600MB) vs LLM-based (API dependency)")
+    print("- Dependency: Rule-based (Local model) vs LLM-based (API dependency)")

--- a/requirements/hhem_integration.txt
+++ b/requirements/hhem_integration.txt
@@ -1,16 +1,19 @@
-# HHEM-2.1-Open Integration Dependencies
-# Required for Vectara HHEM-2.1-Open hallucination detection model
+# Hallucination Detection Dependencies (MiniCheck-Flan-T5-Large)
+# Required for the RuleHallucinationHHEM rule, which detects ungrounded claims
+# by checking whether a response is supported by its context.
+#
+# Model: lytang/MiniCheck-Flan-T5-Large (arXiv:2404.10774).
+# It is a standard T5ForConditionalGeneration checkpoint (no custom remote
+# code), so it loads on any modern transformers version — the previous
+# <4.49 pin (needed by Vectara HHEM's remote code) is no longer required.
 
-# Core transformers library for HHEM model
-# 上限 <4.49：HHEM 官方 remote code (modeling_hhem_v2.py) 为旧版 transformers 编写，
-# transformers 4.49+ 的加载流程会访问 all_tied_weights_keys 属性，旧 remote code 未实现，
-# 导致 "'HHEMv2ForSequenceClassification' object has no attribute 'all_tied_weights_keys'"。
-transformers>=4.30.0,<4.49
+# Core transformers library
+transformers>=4.30.0
 
-# PyTorch (CPU version should be sufficient for HHEM)
+# PyTorch (CPU version is sufficient)
 torch>=1.12.0
 
-# Additional dependencies for model operations
+# Tokenizer dependencies for flan-t5 (SentencePiece)
 sentencepiece>=0.1.99
 tokenizers>=0.13.0
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ agent_requirements = _read_requirements("./requirements/agent.txt")
 hhem_requirements = _read_requirements("./requirements/hhem_integration.txt")
 litellm_requirements = ["litellm>=1.80.0,<1.87.0"]
 retrieval_requirements = _read_requirements("./requirements/retrieval.txt")
-# lmdeploy 单独成组：它硬性要求 transformers>=4.56，与 HHEM 需要的 transformers<4.49 冲突，
-# 因此不并入 optional/all，避免同一环境内 HHEM 无法加载。需要时单独 pip install dingo-python[lmdeploy]。
+# lmdeploy 单独成组：它硬性要求 transformers>=4.56 并拉入大量重依赖，作为可选推理后端不并入
+# optional/all，保持默认环境轻量。需要时单独 pip install dingo-python[lmdeploy]。
+# （注：幻觉检测模型已从 Vectara HHEM 换为标准 T5 的 MiniCheck，不再有 transformers<4.49 上限，
+#   故 lmdeploy 与幻觉检测不再存在版本冲突；此处隔离仅出于依赖体量考虑。）
 lmdeploy_requirements = ["lmdeploy"]
 
 


### PR DESCRIPTION
将本地幻觉检测模型从 Vectara HHEM-2.1-Open 换为
lytang/MiniCheck-Flan-T5-Large（保留类名与注册 id 以向后兼容）。

- 标准 T5 模型，去掉 transformers<4.49 版本限制
- LLM-AggreFact 准确率更高（75.0 vs 71.8）
- 忠实复刻官方 flan-t5 推理（predict 前缀、单步 decoder、 label token [3,209] softmax、按 chunk 取 max）
- 同步更新依赖、示例与中英文幻觉检测指南、自动生成的 metrics.md