### PR TITLE
fix: 循环检测按工具名+参数比较，避免把检索扇出误判为循环

### DIFF
--- a/dingo/model/rule/rule_agent.py
+++ b/dingo/model/rule/rule_agent.py
@@ -5,6 +5,7 @@ These rules run without LLM calls, checking structural properties
 of agent execution traces (loops, token budget, latency anomalies).
 """
 
+import hashlib
 import json
 import statistics
 from typing import Any, List, Optional
@@ -46,9 +47,14 @@ class RuleAgentTraceLoopDetection(BaseRule):
     """Detect repetitive tool call patterns indicating infinite loops.
 
     Input: content = JSON array of tool call objects with 'tool_name' field.
-    Detection: n-gram analysis on tool name sequences.
-    A loop is detected when the same subsequence of 2+ tool names
-    repeats 3 or more consecutive times.
+    Detection: n-gram analysis on tool call signatures.
+    A loop is detected when the same subsequence of 2+ calls repeats 3 or more
+    consecutive times.
+
+    A signature combines the tool name with a fingerprint of its arguments, so
+    a fan-out over one tool with different arguments (eight distinct search
+    queries) is not mistaken for a stuck loop, while the same call issued over
+    and over still is. Calls carrying no arguments compare by name alone.
     """
 
     # Trace-level evaluator: declares input_data_type / eval_layer so agent
@@ -57,24 +63,28 @@ class RuleAgentTraceLoopDetection(BaseRule):
     eval_layer = "trajectory"
     input_data_type = "agent_trace_json"
 
+    _ARGUMENT_KEYS = ("args", "arguments", "tool_input", "input")
+
     _required_fields = [RequiredField.CONTENT]
 
     @classmethod
     def eval(cls, input_data: Data) -> EvalDetail:
         result = EvalDetail(metric=cls.__name__)
 
-        tool_names = cls._extract_tool_names(input_data.content)
-        if len(tool_names) < 6:
+        calls = cls._extract_calls(input_data.content)
+        if len(calls) < 6:
             result.label = [QualityLabel.QUALITY_GOOD]
             return result
 
-        loop_info = cls._detect_loops(tool_names)
+        loop_info = cls._detect_loops([signature for _, signature in calls])
         if loop_info:
+            start = loop_info["position"]
+            pattern = [name for name, _ in calls[start : start + len(loop_info["pattern"])]]
             result.status = True
             result.label = [f"{cls.metric_type}.{cls.__name__}"]
             result.reason = [
-                f"Loop detected: pattern {loop_info['pattern']} "
-                f"repeats {loop_info['count']} times at position {loop_info['position']}"
+                f"Loop detected: pattern {pattern} "
+                f"repeats {loop_info['count']} times at position {start}"
             ]
         else:
             result.label = [QualityLabel.QUALITY_GOOD]
@@ -82,15 +92,31 @@ class RuleAgentTraceLoopDetection(BaseRule):
         return result
 
     @classmethod
-    def _extract_tool_names(cls, content: str) -> List[str]:
-        # Parenthesize the filter: `and` binds tighter than `or`, so without
-        # these parens a non-dict item would reach `item.get("name")` and raise
-        # AttributeError.
-        return [
-            item.get("tool_name", item.get("name", ""))
-            for item in _load_trace_items(content, "tool_calls", "steps")
-            if isinstance(item, dict) and (item.get("tool_name") or item.get("name"))
-        ]
+    def _extract_calls(cls, content: str) -> List[tuple]:
+        """Return ``(tool_name, signature)`` per call, in trace order."""
+        calls = []
+        for item in _load_trace_items(content, "tool_calls", "steps"):
+            if not isinstance(item, dict):
+                continue
+            name = item.get("tool_name") or item.get("name")
+            if not name:
+                continue
+            calls.append((name, f"{name}|{cls._argument_fingerprint(item)}"))
+        return calls
+
+    @classmethod
+    def _argument_fingerprint(cls, item: dict) -> str:
+        """Stable fingerprint of a call's arguments; empty when it has none."""
+        for key in cls._ARGUMENT_KEYS:
+            value = item.get(key)
+            if value in (None, "", {}, []):
+                continue
+            try:
+                normalized = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+            except (TypeError, ValueError):
+                normalized = str(value)
+            return hashlib.sha256(normalized.encode()).hexdigest()[:12]
+        return ""
 
     @classmethod
     def _detect_loops(

--- a/test/scripts/model/rule/test_rule_agent.py
+++ b/test/scripts/model/rule/test_rule_agent.py
@@ -45,6 +45,51 @@ class TestRuleAgentTraceLoopDetection:
         assert res.status is False
         assert res.label == [QualityLabel.QUALITY_GOOD]
 
+    def test_same_tool_with_distinct_arguments_is_not_a_loop(self):
+        # A research fan-out: one tool, eight different queries. Comparing tool
+        # names alone reads this as ['WebSearch','WebSearch'] repeating 4 times.
+        content = json.dumps(
+            {
+                "tool_calls": [
+                    {"tool_name": "WebSearch", "args": {"query": f"topic {i}"}}
+                    for i in range(8)
+                ]
+            }
+        )
+        res = RuleAgentTraceLoopDetection.eval(_data(content))
+        assert res.status is False
+        assert res.label == [QualityLabel.QUALITY_GOOD]
+
+    def test_same_tool_with_identical_arguments_is_flagged(self):
+        # Same tool, same arguments, over and over — a real stuck loop.
+        content = json.dumps(
+            {
+                "tool_calls": [
+                    {"tool_name": "WebSearch", "args": {"query": "same question"}}
+                    for _ in range(6)
+                ]
+            }
+        )
+        res = RuleAgentTraceLoopDetection.eval(_data(content))
+        assert res.status is True
+        assert res.reason is not None and "Loop detected" in res.reason[0]
+
+    def test_loop_reason_names_the_repeated_tool_not_its_signature(self):
+        content = json.dumps(
+            {
+                "tool_calls": [
+                    {"tool_name": "read_file", "args": {"path": "a.md"}}
+                    for _ in range(6)
+                ]
+            }
+        )
+        res = RuleAgentTraceLoopDetection.eval(_data(content))
+        assert res.status is True
+        # The reported pattern stays human-readable: tool names, not the
+        # internal argument fingerprint used for comparison.
+        assert "read_file" in res.reason[0]
+        assert "path" not in res.reason[0]
+
     def test_short_sequence_passes(self):
         # Fewer than 6 tool names → early pass, no analysis.
         content = json.dumps([{"tool_name": "a"}, {"tool_name": "b"}])


### PR DESCRIPTION
RuleAgentTraceLoopDetection 只比较工具名序列，因此一次检索扇出（同一个
WebSearch、八个不同 query）与卡死循环无法区分：n-gram 会把它读成
['WebSearch','WebSearch'] 重复 4 次并判为循环。

改为在"工具名 + 参数指纹"的签名序列上做 n-gram：参数不同则签名不同，扇出
不再触发；同一调用反复重试仍会被检出。没有参数的调用退回按名比较，旧行为
不变。参数键兼容 args / arguments / tool_input / input。

reason 仍按工具名展示（pattern ['Read','Read']），不暴露内部指纹。