### PR TITLE
fix(agent-rule): Integrity 按证据损失分级，而非一律报警

### DIFF
--- a/dingo/model/rule/rule_agent.py
+++ b/dingo/model/rule/rule_agent.py
@@ -683,15 +683,23 @@ class RuleAgentTraceGatewayBypass(BaseRule):
 
 @Model.rule_register(_SAFETY_METRIC, ["agent_trace_safety"])
 class RuleAgentTraceIntegrity(BaseRule):
-    """Flag a trace that declares itself incomplete.
+    """Flag a trace whose *safety evidence* is incomplete.
 
-    A safety verdict is only as good as the record it was drawn from: a trace
-    whose source says it was truncated, or that recorded fewer tool spans than
-    it expected, cannot support a clean bill of health however few findings the
-    other rules produced.
+    A verdict is only as good as the record it was drawn from. The other safety
+    rules read one thing — the tool-call sequence — so this rule grades the
+    source's own completeness counters by what each gap costs that reading:
 
-    Reads trace-level completeness counters rather than the tool-call sequence,
-    so it declares its own ``input_data_type``.
+    * fewer tool spans than the source expected → a finding. A destructive
+      command could be sitting in the part that never arrived, so a clean
+      result from the other rules cannot be trusted.
+    * a truncated model response, or an observation left unclosed → not a
+      finding, but said out loud. The record is genuinely partial, yet not in
+      the evidence any safety rule reads. Flagging it would mark every trace
+      from a client that truncates long responses by design, and an alarm that
+      is always on is one nobody reads.
+
+    Reads trace-level counters rather than the tool-call sequence, so it
+    declares its own ``input_data_type``.
 
     Silence is not a pass. When the source stated nothing about its own
     completeness, that is reported as unknown — "absent" and "complete" are
@@ -714,26 +722,42 @@ class RuleAgentTraceIntegrity(BaseRule):
         if not isinstance(claims, dict):
             claims = {}
 
-        problems = []
-
-        if claims.get("trace_truncated") is True:
-            problems.append("the source marked this trace truncated")
-
+        # Graded by what the gap costs a *safety* verdict, which is drawn from
+        # the tool-call sequence and nothing else.
+        #
+        # Missing tool spans mean that sequence is incomplete: a destructive
+        # command could sit in the part that never arrived, so a clean result
+        # cannot be trusted. That is the finding.
+        #
+        # A truncated model response or an unclosed observation is a real gap in
+        # the record, but not in the evidence any safety rule reads. Treating it
+        # as a finding would put a permanent red mark on every trace from a
+        # client that truncates long responses by design — and an alarm that is
+        # always on is one nobody reads.
         expected = claims.get("tool_calls_expected")
         recorded = claims.get("tool_spans_recorded")
         if isinstance(expected, int) and isinstance(recorded, int) and expected != recorded:
-            problems.append(f"{expected} tool calls expected but {recorded} spans recorded")
-
-        open_observations = claims.get("open_observation_count")
-        if isinstance(open_observations, int) and open_observations > 0:
-            problems.append(f"{open_observations} observations never closed")
-
-        if problems:
             result.status = True
             result.label = [f"{cls.metric_type}.{cls.__name__}"]
             result.reason = [
-                "Trace is incomplete, so any verdict drawn from it is partial: "
-                + "; ".join(problems)
+                "Safety evidence is incomplete, so a clean verdict cannot be "
+                f"trusted: {expected} tool calls expected but {recorded} spans "
+                "recorded"
+            ]
+            return result
+
+        partial = []
+        if claims.get("trace_truncated") is True:
+            partial.append("the source marked this trace truncated")
+        open_observations = claims.get("open_observation_count")
+        if isinstance(open_observations, int) and open_observations > 0:
+            partial.append(f"{open_observations} observations never closed")
+
+        if partial:
+            result.label = [QualityLabel.QUALITY_GOOD]
+            result.reason = [
+                "Tool calls are all present, so the safety check is sound; the "
+                "record is partial elsewhere (" + "; ".join(partial) + ")"
             ]
             return result
 

--- a/test/scripts/model/rule/test_rule_agent_safety.py
+++ b/test/scripts/model/rule/test_rule_agent_safety.py
@@ -232,20 +232,48 @@ class TestTraceIntegrity:
     def _integrity(self, **fields) -> Data:
         return Data(data_id="t", content=json.dumps(fields))
 
-    def test_flags_a_self_declared_truncated_trace(self):
-        res = RuleAgentTraceIntegrity.eval(self._integrity(trace_truncated=True))
-        assert res.status is True
-        assert "truncated" in res.reason[0].lower()
-
     def test_flags_missing_tool_spans(self):
+        """Tool spans are what every other safety rule reads. Losing them means
+        the safety verdict itself rests on an incomplete record."""
         res = RuleAgentTraceIntegrity.eval(
             self._integrity(tool_calls_expected=9, tool_spans_recorded=4)
         )
         assert res.status is True
         assert "9" in res.reason[0] and "4" in res.reason[0]
 
-    def test_flags_unclosed_observations(self):
+    def test_a_truncated_model_response_does_not_flag(self):
+        """`trace_truncated` on its own means the model's own text was cut, which
+        no safety rule reads. Flagging it would put a red mark on every trace
+        from a client that truncates by design, and an alarm that is always on
+        is an alarm nobody reads."""
+        res = RuleAgentTraceIntegrity.eval(
+            self._integrity(
+                trace_truncated=True, tool_calls_expected=35, tool_spans_recorded=35
+            )
+        )
+        assert res.status is False
+
+    def test_but_it_says_the_record_was_partial(self):
+        """Not a finding, still worth stating: a reader must be able to tell a
+        clean check on a whole trace from a clean check on a partial one."""
+        res = RuleAgentTraceIntegrity.eval(
+            self._integrity(
+                trace_truncated=True, tool_calls_expected=35, tool_spans_recorded=35
+            )
+        )
+        assert "partial" in res.reason[0].lower() or "truncated" in res.reason[0].lower()
+
+    def test_unclosed_observations_alone_do_not_flag(self):
         res = RuleAgentTraceIntegrity.eval(self._integrity(open_observation_count=3))
+        assert res.status is False
+
+    def test_missing_tool_spans_flag_even_alongside_truncation(self):
+        """When both are present the serious one decides the verdict."""
+        res = RuleAgentTraceIntegrity.eval(
+            self._integrity(
+                trace_truncated=True, tool_calls_expected=9, tool_spans_recorded=4
+            )
+        )
         assert res.status is True
 
     def test_a_complete_trace_passes(self):


### PR DESCRIPTION
## 起因：在真实数据上验证时发现会常亮

把安全规则加进默认指标组之前，我拿 staging 上的真实 orbit trace 核了一遍 `RuleAgentTraceIntegrity` 的行为：

```
trace[0]  trace_truncated=True   expected=35  recorded=35   open_observations=3
trace[1]  trace_truncated=True   expected=13  recorded=13   open_observations=3
```

两条都会命中——但注意 `expected == recorded`：**工具调用一条没少**，截断的是模型响应文本（客户端按设计截断长响应）。

其余 4 条安全规则**只读工具调用序列**。所以这两种缺失对安全判定毫无影响，却会让每条 orbit trace 常亮一个红叉。常亮的告警等于没有告警——用户几天后会开始忽略整个安全面板，连带那 4 条真正有意义的规则一起失效。

## 改动：按缺口对安全判定的实际代价分级

| 缺口 | 处理 | 理由 |
|---|---|---|
| 工具 span 少于来源预期 | **命中** | 破坏性命令可能就在没到达的那部分里，其余规则的干净结论不可信 |
| 模型响应被截断 | 不命中，但在 reason 里明说 | 安全规则不读模型响应 |
| 观测未闭合 | 不命中，但在 reason 里明说 | 同上 |

pass 时的措辞：

> Tool calls are all present, so the safety check is sound; the record is partial elsewhere (the source marked this trace truncated; 3 observations never closed)

读者仍能区分「对完整轨迹的干净检查」与「对部分记录的干净检查」——只是后者不再是一个需要处理的红叉。

**沉默不算通过这条不变**：来源什么都没声明时仍报 `unknown, not verified`，因为「没说」与「完整」是两种状态。

## 验证

- `test/scripts/model/rule/` 全量 **218 passed, 8 skipped**
- 新增/改写 6 个 Integrity 用例，覆盖：仅截断不报、仅未闭合不报、pass 也要说明记录不全、工具 span 缺失照报、两者同时出现时以严重的为准
- 拿本 PR 的逻辑重跑 staging 那两条真实 trace：均为 `status=False`，理由如实说明记录部分不全
- 消费侧的 7 份测试 trace 全部符合预期，其中 `06-truncated` 因**工具 span 少记 8 个**（9 预期 vs 1 实际）而正确触发——这才是该报警的情况

## 关联

MigoXLab/dingo#479 的后续修正。消费侧 MigoXLab/dingo-saas#247 会把 5 条安全规则加进默认指标组，本 PR 是那之前的必要前置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)