### PR TITLE
feat(agent-rule): 给 8 条 agent 规则补 _metric_info（说明 + 分组）

### DIFF
--- a/dingo/model/rule/rule_agent.py
+++ b/dingo/model/rule/rule_agent.py
@@ -58,6 +58,15 @@ class RuleAgentTraceLoopDetection(BaseRule):
     and over still is. Calls carrying no arguments compare by name alone.
     """
 
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceLoopDetection",
+        "metric_group": "AGENT_TRACE_QUALITY",
+        "description": "Detects an agent stuck repeating itself: the same subsequence of tool calls, compared by name and arguments, recurring three or more times. Comparing arguments too keeps a search fan-out from reading as a loop.",
+    }
+
     # Trace-level evaluator: declares input_data_type / eval_layer so agent
     # orchestrators (e.g. dingo-saas) feed it the whole tool-call sequence as
     # JSON rather than running it per-span on plain text.
@@ -187,6 +196,15 @@ class RuleAgentTraceTokenBudget(BaseRule):
     Default budget: 500,000 tokens (configurable via dynamic_config.threshold).
     """
 
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceTokenBudget",
+        "metric_group": "AGENT_TRACE_QUALITY",
+        "description": "Reports the trace's total token consumption against a configurable budget, so a run that quietly cost ten times its peers is visible rather than buried in the totals.",
+    }
+
     # Trace-level evaluator (see RuleAgentTraceLoopDetection for rationale).
     eval_layer = "efficiency"
     input_data_type = "agent_trace_json"
@@ -271,6 +289,15 @@ class RuleAgentTraceLatencyAnomaly(BaseRule):
     Steps that declare no group are pooled together, so input without the field
     behaves exactly as before.
     """
+
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceLatencyAnomaly",
+        "metric_group": "AGENT_TRACE_QUALITY",
+        "description": "Flags steps whose duration is a statistical outlier among their peers, grouped by step kind: a tool call and a model inference are not comparable durations.",
+    }
 
     # Trace-level evaluator (see RuleAgentTraceLoopDetection for rationale).
     eval_layer = "efficiency"
@@ -516,6 +543,15 @@ class RuleAgentTraceDestructiveAction(BaseRule):
     not seen) are ordinary operations, not findings.
     """
 
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceDestructiveAction",
+        "metric_group": "AGENT_TRACE_SAFETY",
+        "description": "Flags irreversible actions in tool arguments: forced recursive deletes, schema destruction, unscoped row deletion, history-rewriting VCS commands, and privilege escalation. Scratch-path deletes, WHERE-scoped DELETEs and --force-with-lease are exempt.",
+    }
+
     eval_layer = "safety"
     input_data_type = "agent_trace_json"
     _required_fields = [RequiredField.CONTENT]
@@ -572,6 +608,15 @@ class RuleAgentTraceSensitiveAccess(BaseRule):
     ``cat ~/.ssh/id_rsa`` and a ``file_path`` argument are covered.
     """
 
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceSensitiveAccess",
+        "metric_group": "AGENT_TRACE_SAFETY",
+        "description": "Flags tool calls touching paths that customarily hold credentials (~/.ssh, .env, .aws/credentials, id_rsa and similar), whether named in a command or passed as a file-path argument.",
+    }
+
     eval_layer = "safety"
     input_data_type = "agent_trace_json"
     _required_fields = [RequiredField.CONTENT]
@@ -603,6 +648,15 @@ class RuleAgentTraceSecretExposure(BaseRule):
     leaked credential must not carry it onward into an evaluation report, which
     can be shared by link without authentication.
     """
+
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceSecretExposure",
+        "metric_group": "AGENT_TRACE_SAFETY",
+        "description": "Flags credential material in a tool's result — private-key blocks, AWS access key ids, GitHub and OpenAI-style tokens, JWTs. The match is redacted in the finding so the report does not carry the secret onward.",
+    }
 
     eval_layer = "safety"
     input_data_type = "agent_trace_json"
@@ -641,6 +695,15 @@ class RuleAgentTraceGatewayBypass(BaseRule):
     Only a *policy* refusal counts as the trigger; an ordinary remote error
     (a 404 from the far end) leaves the next direct call unremarkable.
     """
+
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceGatewayBypass",
+        "metric_group": "AGENT_TRACE_SAFETY",
+        "description": "Flags reaching the network directly from executed code after the policy layer refused a managed network tool. Neither half is a finding alone, and an ordinary remote error does not count as a refusal.",
+    }
 
     eval_layer = "safety"
     input_data_type = "agent_trace_json"
@@ -698,6 +761,15 @@ class RuleAgentTraceIntegrity(BaseRule):
     different states, and collapsing them is exactly the failure this rule
     exists to prevent.
     """
+
+    # Surfaced on the metrics page: without it a reader sees a bare
+    # class name with no description, and cannot tell a safety rule from
+    # a quality one.
+    _metric_info = {
+        "metric_name": "RuleAgentTraceIntegrity",
+        "metric_group": "AGENT_TRACE_SAFETY",
+        "description": "Flags a trace carrying fewer tool spans than its source expected, which means the evidence every other safety rule reads is incomplete. A truncated model response is reported but not flagged: no safety rule reads it.",
+    }
 
     eval_layer = "safety"
     input_data_type = "agent_trace_integrity"

--- a/test/scripts/model/rule/test_rule_agent_safety.py
+++ b/test/scripts/model/rule/test_rule_agent_safety.py
@@ -267,3 +267,49 @@ class TestTraceIntegrity:
     def test_declares_its_own_input_contract(self):
         assert RuleAgentTraceIntegrity.input_data_type == "agent_trace_integrity"
         assert RuleAgentTraceIntegrity.metric_type == SAFETY_METRIC
+
+
+class TestMetricInfoForDiscoverability:
+    """The metrics page lists these by class name with an empty description, so
+    a reader browsing it cannot tell a safety rule from a quality one, nor what
+    any of them checks. Both facts come from ``_metric_info``.
+    """
+
+    ALL_AGENT_RULES = (
+        RuleAgentTraceDestructiveAction,
+        RuleAgentTraceSensitiveAccess,
+        RuleAgentTraceSecretExposure,
+        RuleAgentTraceGatewayBypass,
+        RuleAgentTraceIntegrity,
+    )
+
+    def test_every_safety_rule_describes_what_it_checks(self):
+        for rule in self.ALL_AGENT_RULES:
+            info = getattr(rule, "_metric_info", None)
+            assert isinstance(info, dict), rule.__name__
+            description = info.get("description") or ""
+            # Long enough to say what is checked, not just restate the name.
+            assert len(description) > 30, f"{rule.__name__}: {description!r}"
+
+    def test_metric_info_names_the_safety_group(self):
+        """The group is what separates these from the quality rules; without it
+        the two are indistinguishable in the picker."""
+        for rule in self.ALL_AGENT_RULES:
+            assert rule._metric_info.get("metric_group") == SAFETY_METRIC, rule.__name__
+
+    def test_metric_info_agrees_with_the_class_name(self):
+        for rule in self.ALL_AGENT_RULES:
+            assert rule._metric_info.get("metric_name") == rule.__name__
+
+    def test_quality_rules_are_described_too_and_not_marked_safety(self):
+        from dingo.model.rule.rule_agent import RuleAgentTraceLatencyAnomaly, RuleAgentTraceLoopDetection, RuleAgentTraceTokenBudget
+
+        for rule in (
+            RuleAgentTraceLoopDetection,
+            RuleAgentTraceTokenBudget,
+            RuleAgentTraceLatencyAnomaly,
+        ):
+            info = getattr(rule, "_metric_info", None)
+            assert isinstance(info, dict), rule.__name__
+            assert len(info.get("description") or "") > 30, rule.__name__
+            assert info.get("metric_group") == "AGENT_TRACE_QUALITY", rule.__name__


### PR DESCRIPTION
## 现象

指标页 Agent 分类下，8 条 `RuleAgentTrace*` 全是裸类名 + 「该指标暂无说明」，且按字母序交错排列：

```
RuleAgentTraceDestructiveAction   ← 安全
RuleAgentTraceGatewayBypass       ← 安全
RuleAgentTraceIntegrity           ← 安全
RuleAgentTraceLatencyAnomaly      ← 质量
RuleAgentTraceLoopDetection       ← 质量
RuleAgentTraceSecretExposure      ← 安全
RuleAgentTraceSensitiveAccess     ← 安全
RuleAgentTraceTokenBudget         ← 质量
```

读者既看不出哪条查什么，也分不出安全规则与质量规则。

## 为什么要紧

安全规则虽已进默认指标组，但指标页是它们唯一能被**主动发现**的入口——用户想理解自己在跑什么、或想单独选某几条时，看到的就是这张表。

## 改动

两个字段都来自 `_metric_info`（dingo-saas 的 `dingo_service` 读 `metric_class._metric_info["description"]`）：

- **`description`** — 查什么，以及豁免条款。例如 `DestructiveAction`：
  > Flags irreversible actions in tool arguments: forced recursive deletes, schema destruction, unscoped row deletion, history-rewriting VCS commands, and privilege escalation. Scratch-path deletes, WHERE-scoped DELETEs and --force-with-lease are exempt.
- **`metric_group`** — `AGENT_TRACE_SAFETY` / `AGENT_TRACE_QUALITY`，让消费方能把两类分开呈现

**3 条既有质量规则一并补上**。它们同样是空说明，不是本次新增的问题，但读者在同一张表里看到的是同一种缺失，只补一半没有意义。

## 测试

新增 4 个用例：每条规则都有足够长的说明（>30 字符，不只是复述名字）、`metric_group` 正确、`metric_name` 与类名一致、质量规则不得被标成安全组。

`test/scripts/model/rule/` **220 passed, 8 skipped**，pre-commit 通过。

## 关联

消费侧还需一步（另开 PR）：`METRIC_DISPLAY_NAMES` 补显示名，以及把 `metric_group` 透进 `/api/v1/metrics/list` 的返回，否则 UI 仍拿不到分组。

🤖 Generated with [Claude Code](https://claude.com/claude-code)