### PR TITLE
feat(retrieval): 新增 sciverse scp 检索后端

### DIFF
--- a/dingo/retrieval/backends/sciverse_mcp.py
+++ b/dingo/retrieval/backends/sciverse_mcp.py
@@ -1,0 +1,205 @@
+"""
+Sciverse MCP backend for retrieval evaluation.
+
+Connects to the Sciverse SCP Server through the SCP Hub MCP gateway
+(streamable-http transport) and evaluates its ``semantic_search`` tool
+against MTEB retrieval benchmarks.
+
+Unlike the ``agentic`` / ``meta_search`` backends (which reach Sciverse over
+plain REST at ``api.sciverse.space``), this backend speaks MCP to the SCP Hub
+gateway and authenticates with the ``SCP-HUB-API-KEY`` header.
+
+The MCP client API is asynchronous, but ``SearchClient.search`` is synchronous
+and called concurrently from a ThreadPoolExecutor. Each ``search`` opens its
+own event loop and its own MCP connection (``asyncio.run``), so concurrent
+worker threads never share a session — the safe way to parallelize a
+single-in-flight streamable-http transport.
+
+    dingo eval-retrieval \
+      --backend sciverse_mcp \
+      --tasks SciFact \
+      --api-url https://scp.intern-ai.org.cn/api/v1/mcp/43/Sciverse \
+      --api-token YOUR_SCP_HUB_API_KEY \
+      --limit 100 \
+      --max-queries 5 \
+      -o outputs/retrieval_eval
+"""
+
+from __future__ import annotations
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+
+from dingo.retrieval.search_client import PaperResult, SearchClient, SearchResponse, register_backend
+
+logger = logging.getLogger(__name__)
+
+#: Header the SCP Hub gateway authenticates with (your SCP Platform key).
+_API_KEY_HEADER = "SCP-HUB-API-KEY"
+
+
+@register_backend("sciverse_mcp")
+class SciverseMCPClient(SearchClient):
+    name = "sciverse-mcp-api"
+
+    def __init__(
+        self,
+        api_url: str = "https://scp.intern-ai.org.cn/api/v1/mcp/43/Sciverse",
+        api_token: str | None = None,
+        timeout: float = 30.0,
+        rate_limit: float = 1.0,
+        **_kwargs: Any,
+    ) -> None:
+        self.server_url = api_url
+        self.timeout = timeout
+        self.api_key = api_token or os.environ.get("SCP_HUB_API_KEY")
+        self.rate_limit = max(0.0, float(rate_limit))
+        self._last_request_time = 0.0
+        self._lock = threading.Lock()
+
+        if not self.api_key:
+            logger.warning(
+                "sciverse_mcp: no api_token/SCP_HUB_API_KEY set; "
+                "the SCP Hub gateway will reject requests."
+            )
+        logger.info(
+            "SciverseMCP backend: %s (api_key=%s, rate_limit=%.1fs)",
+            self.server_url,
+            "set" if self.api_key else "unset",
+            self.rate_limit,
+        )
+
+    def _rate_limit_wait(self) -> None:
+        if self.rate_limit <= 0:
+            return
+        sleep_time = 0.0
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_request_time
+            if elapsed < self.rate_limit:
+                sleep_time = self.rate_limit - elapsed
+            self._last_request_time = now + sleep_time
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+
+    @asynccontextmanager
+    async def _open_session(self):
+        """Open an MCP session over streamable-http, yielding it, then close.
+
+        Each call establishes its own connection and event loop, so concurrent
+        worker threads never share a session.
+        """
+        from mcp import ClientSession
+        # streamablehttp_client takes headers/timeout directly; the newer
+        # streamable_http_client drops them in favor of a pre-built http_client,
+        # which does not fit the SCP-HUB-API-KEY header injection here.
+        from mcp.client.streamable_http import streamablehttp_client
+
+        headers = {_API_KEY_HEADER: self.api_key} if self.api_key else {}
+        async with streamablehttp_client(
+            url=self.server_url,
+            headers=headers,
+            timeout=self.timeout,
+        ) as (
+            read,
+            write,
+            _get_session_id,
+        ):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+    async def _search_async(self, query: str, limit: int) -> list[dict[str, Any]]:
+        async with self._open_session() as session:
+            result = await session.call_tool(
+                "semantic_search",
+                arguments={"query": query, "top_k": int(limit)},
+            )
+        return self._extract_hits_from_result(result)
+
+    def search(self, query: str, limit: int = 100) -> SearchResponse:
+        self._rate_limit_wait()
+        start = time.monotonic()
+        try:
+            hits = asyncio.run(self._search_async(query, limit))
+            elapsed_ms = (time.monotonic() - start) * 1000
+            return SearchResponse(
+                query=query,
+                results=self._parse_hits(hits),
+                response_time_ms=elapsed_ms,
+                status_code=200,
+            )
+        except Exception as e:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            return SearchResponse(
+                query=query,
+                results=[],
+                response_time_ms=elapsed_ms,
+                status_code=0,
+                error=str(e),
+            )
+
+    @staticmethod
+    def _result_text(result: Any) -> str:
+        """Concatenate the text content blocks of an MCP tool result."""
+        if isinstance(result, dict):
+            content_list = result.get("content") or []
+        else:
+            content_list = getattr(result, "content", []) or []
+        texts: list[str] = []
+        for item in content_list:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    texts.append(item.get("text") or "")
+            elif getattr(item, "type", None) == "text":
+                texts.append(getattr(item, "text", "") or "")
+        return "".join(texts)
+
+    @classmethod
+    def _extract_hits_from_result(cls, result: Any) -> list[dict[str, Any]]:
+        """Extract the ``hits`` array from a ``semantic_search`` tool result."""
+        text = cls._result_text(result)
+        if not text:
+            return []
+        try:
+            payload = json.loads(text)
+        except (ValueError, TypeError):
+            logger.warning("sciverse_mcp: semantic_search returned non-JSON text")
+            return []
+        if not isinstance(payload, dict):
+            return []
+        hits = payload.get("hits")
+        return hits if isinstance(hits, list) else []
+
+    @staticmethod
+    def _parse_hits(hits: list[dict[str, Any]]) -> list[PaperResult]:
+        """Map ``semantic_search`` hits to PaperResult, one per paper.
+
+        A paper contributes up to ~3 chunks; retrieval metrics rank papers,
+        not chunks. Keep the first (highest-ranked) chunk of each doc_id and
+        drop hits with no doc_id — they cannot be scored against qrels.
+        """
+        results: list[PaperResult] = []
+        seen: set[str] = set()
+        for hit in hits:
+            if not isinstance(hit, dict):
+                continue
+            doc_id = str(hit.get("doc_id") or "")
+            if not doc_id or doc_id in seen:
+                continue
+            seen.add(doc_id)
+            results.append(
+                PaperResult(
+                    paper_id=doc_id,
+                    title=str(hit.get("title") or ""),
+                    abstract=str(hit.get("chunk") or ""),
+                    score=float(hit.get("score") or 0.0),
+                    raw=hit,
+                )
+            )
+        return results

--- a/dingo/retrieval/search_client.py
+++ b/dingo/retrieval/search_client.py
@@ -97,6 +97,7 @@ def _load_builtin_backends():
         "dingo.retrieval.backends.agentic",
         "dingo.retrieval.backends.google_scholar",
         "dingo.retrieval.backends.openalex",
+        "dingo.retrieval.backends.sciverse_mcp",
         "dingo.retrieval.backends.semantic_scholar",
     ):
         try:

--- a/requirements/retrieval.txt
+++ b/requirements/retrieval.txt
@@ -1,2 +1,3 @@
 mteb>=1.0.0
 pytrec-eval-terrier>=0.5.6
+mcp>=1.24.0

--- a/test/scripts/retrieval/test_sciverse_mcp.py
+++ b/test/scripts/retrieval/test_sciverse_mcp.py
@@ -1,0 +1,195 @@
+"""Unit tests for dingo.retrieval.backends.sciverse_mcp"""
+
+import pytest
+
+from dingo.retrieval.backends.sciverse_mcp import SciverseMCPClient
+
+
+class TestParseHits:
+    def test_maps_semantic_search_fields(self):
+        hits = [
+            {
+                "chunk_id": "c1",
+                "doc_id": "d-aaa",
+                "chunk": "attention is all you need",
+                "score": 0.91,
+                "title": "Transformer",
+                "abstract": "abstract text",
+                "offset": 128,
+            }
+        ]
+
+        results = SciverseMCPClient._parse_hits(hits)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.paper_id == "d-aaa"
+        assert r.title == "Transformer"
+        assert r.abstract == "attention is all you need"
+        assert r.score == 0.91
+        assert r.raw == hits[0]
+
+    def test_dedups_chunks_of_same_paper_keeping_best_rank(self):
+        # semantic_search returns up to ~3 chunks per paper; retrieval metrics
+        # need one entry per paper, ranked. Keep the first (best) chunk's rank.
+        hits = [
+            {"doc_id": "d-aaa", "chunk": "chunk 1", "score": 0.9},
+            {"doc_id": "d-bbb", "chunk": "other paper", "score": 0.8},
+            {"doc_id": "d-aaa", "chunk": "chunk 2 same paper", "score": 0.7},
+        ]
+
+        results = SciverseMCPClient._parse_hits(hits)
+
+        assert [r.paper_id for r in results] == ["d-aaa", "d-bbb"]
+        assert results[0].abstract == "chunk 1"
+
+    def test_skips_hits_without_doc_id(self):
+        hits = [
+            {"doc_id": "", "chunk": "no id", "score": 0.9},
+            {"doc_id": "d-ok", "chunk": "has id", "score": 0.8},
+        ]
+
+        results = SciverseMCPClient._parse_hits(hits)
+
+        assert [r.paper_id for r in results] == ["d-ok"]
+
+
+class TestExtractHitsFromResult:
+    def test_parses_hits_from_text_content_block(self):
+        # MCP tool results carry the JSON payload inside text content blocks.
+        class _Block:
+            type = "text"
+            text = '{"hits": [{"doc_id": "d1", "chunk": "x", "score": 0.5}]}'
+
+        class _Result:
+            content = [_Block()]
+
+        hits = SciverseMCPClient._extract_hits_from_result(_Result())
+
+        assert hits == [{"doc_id": "d1", "chunk": "x", "score": 0.5}]
+
+    def test_returns_empty_when_no_hits_key(self):
+        class _Block:
+            type = "text"
+            text = '{"results": []}'
+
+        class _Result:
+            content = [_Block()]
+
+        assert SciverseMCPClient._extract_hits_from_result(_Result()) == []
+
+    def test_returns_empty_on_non_json_text(self):
+        class _Block:
+            type = "text"
+            text = "not json at all"
+
+        class _Result:
+            content = [_Block()]
+
+        assert SciverseMCPClient._extract_hits_from_result(_Result()) == []
+
+
+class _FakeBlock:
+    type = "text"
+
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeResult:
+    def __init__(self, text):
+        self.content = [_FakeBlock(text)]
+
+
+class _FakeSession:
+    """Records call_tool invocations and returns a canned result."""
+
+    def __init__(self, result_text):
+        self._result_text = result_text
+        self.calls = []
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return _FakeResult(self._result_text)
+
+
+def _fake_open_session(session):
+    """Build a factory returning an async context manager yielding *session*."""
+    class _Ctx:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def _factory():
+        return _Ctx()
+
+    return _factory
+
+
+class TestSearch:
+    def _client_with_session(self, session):
+        client = SciverseMCPClient(
+            api_url="https://scp.example/mcp",
+            api_token="k",
+            rate_limit=0,
+        )
+        # Inject the fake session, bypassing the real MCP connection.
+        client._open_session = _fake_open_session(session)
+        return client
+
+    def test_search_calls_semantic_search_and_returns_results(self):
+        session = _FakeSession(
+            '{"hits": ['
+            '{"doc_id": "d1", "chunk": "a", "score": 0.9, "title": "T1"},'
+            '{"doc_id": "d1", "chunk": "dup", "score": 0.5},'
+            '{"doc_id": "d2", "chunk": "b", "score": 0.4, "title": "T2"}'
+            ']}'
+        )
+        client = self._client_with_session(session)
+
+        resp = client.search("how does attention work?", limit=25)
+
+        assert resp.status_code == 200
+        assert resp.error is None
+        assert session.calls == [
+            ("semantic_search", {"query": "how does attention work?", "top_k": 25})
+        ]
+        assert [r.paper_id for r in resp.results] == ["d1", "d2"]
+
+    def test_search_reports_connection_error(self):
+        client = SciverseMCPClient(
+            api_url="https://scp.example/mcp", api_token="k", rate_limit=0
+        )
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("connect failed")
+
+        client._open_session = _boom
+
+        resp = client.search("q")
+
+        assert resp.status_code == 0
+        assert resp.results == []
+        assert "connect failed" in resp.error
+
+
+class TestSearchIntegration:
+    """Exercises the real MCP client path (no network reachable)."""
+
+    def test_unreachable_server_degrades_to_error_response(self):
+        pytest.importorskip("mcp")
+        client = SciverseMCPClient(
+            api_url="http://127.0.0.1:1/does-not-exist",
+            api_token="k",
+            timeout=2.0,
+            rate_limit=0,
+        )
+
+        resp = client.search("q", limit=3)
+
+        # A dead endpoint must surface as an error response, never raise.
+        assert resp.status_code == 0
+        assert resp.results == []
+        assert resp.error

--- a/test/scripts/retrieval/test_search_client.py
+++ b/test/scripts/retrieval/test_search_client.py
@@ -52,6 +52,7 @@ class TestBackendRegistry:
         assert "google_scholar" in backends
         assert "meta_search" in backends
         assert "openalex" in backends
+        assert "sciverse_mcp" in backends
 
     def test_create_unknown_backend_raises(self):
         with pytest.raises(ValueError, match="Unknown backend"):


### PR DESCRIPTION
通过 SCP Hub MCP 网关(streamable-http 传输)接入 Sciverse SCP Server, 在 MTEB 检索基准上评测其 semantic_search 工具。

- 新增 SciverseMCPClient,注册为 sciverse_mcp 后端
- 使用 SCP-HUB-API-KEY 请求头鉴权(区别于 agentic/meta_search 走 REST + Bearer)
- search() 默认调用 semantic_search;每次查询独立开启事件循环与 MCP 连接 (asyncio.run),使 ThreadPoolExecutor 并发调用天然线程安全
- chunk→paper 级去重:按 doc_id 保留最高排名 chunk,跳过空 doc_id
- mcp 作为显式直接依赖加入 requirements/retrieval.txt(>=1.24.0)
- 补充单元测试(字段映射/去重/JSON 解析/search 调用与错误降级)与集成测试

用法：

```
dingo eval-retrieval \
  --backend sciverse_mcp \
  --tasks SciFact \
  --api-url https://scp.intern-ai.org.cn/api/v1/mcp/43/Sciverse \
  --api-token YOUR_SCP_HUB_API_KEY \
  --limit 100 --max-queries 5 \
  -o outputs/retrieval_eval
```